### PR TITLE
Fixes issue with Get-Website when there are multiple sites

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -137,7 +137,7 @@ function Set-TargetResource
         {
             Throw "Please ensure that WebAdministration module is installed."
         }
-        $website = get-website $Name
+        $website = Get-Website | Where-Object {$_.Name -eq $name}
 
         if($website -ne $null)
         {
@@ -324,7 +324,7 @@ function Set-TargetResource
     { 
         try
         {
-            $website = get-website $Name
+            $website = Get-Website | Where-Object {$_.Name -eq $name}
             if($website -ne $null)
             {
                 Remove-website -name $Name

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -621,7 +621,7 @@ function compareWebsiteBindings
     #check to see if actual settings have been passed in. If not get them from website
     if($ActualBindings -eq $null)
     {
-        $ActualBindings = Get-Website $Name | Get-WebBinding
+        $ActualBindings = Get-Website | Where-Object {$_.Name -eq $Name} | Get-WebBinding
 
         #Format Binding information: Split BindingInfo into individual Properties (IPAddress:Port:HostName)
         $ActualBindingObjects = @()


### PR DESCRIPTION
In 2008R2 Get-Website -Name $Name will return all websites and doesn't filter correctly.  So if there is more than one website and it isn't the first returned then it doesn't think the site exists even if it does.