### PR TITLE
Modifying xWebsite schema to have PhysicalPath be required

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -27,7 +27,11 @@ function Get-TargetResource
     (   
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [string]$Name
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PhysicalPath
     )
 
         $getTargetResourceResult = $null;

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("1.0.0")] 
+[ClassVersion("1.0.0")]
 Class MSFT_xWebBindingInformation
 {
     [write]UInt16 Port;
@@ -10,17 +10,17 @@ Class MSFT_xWebBindingInformation
 };
 
 
-[ClassVersion("2.0.0"), FriendlyName("xWebsite")] 
+[ClassVersion("2.0.0"), FriendlyName("xWebsite")]
 class MSFT_xWebsite : OMI_BaseResource
 {
   [Key] string Name;
-  [write] string PhysicalPath;
+  [Required] string PhysicalPath;
   [write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
   [write,ValueMap{"Started","Stopped"},Values{"Started", "Stopped"}] string State;
   [write, EmbeddedInstance("MSFT_xWebBindingInformation"), Description("Hashtable containing binding information (Port, Protocol, IPAddress, HostName, CertificateThumbPrint, CertificateStore)")] string BindingInfo[];
   [write] string ApplicationPool;
   [read] string Id;
   [write, Description("The default pages for the website")] String DefaultPage[];
-}; 
+};
 
 

--- a/Tests/MSFT_xWebBindingInformation.Tests.ps1
+++ b/Tests/MSFT_xWebBindingInformation.Tests.ps1
@@ -30,6 +30,7 @@ Describe "MSFT_xWebBindingInformation" {
             {
                 Name = 'foobar'
                 Ensure = 'absent'
+                PhysicalPath = "$env:temp\foo"
             }
         }
 

--- a/Tests/MSFT_xWebBindingInformation.Tests.ps1
+++ b/Tests/MSFT_xWebBindingInformation.Tests.ps1
@@ -35,7 +35,7 @@ Describe "MSFT_xWebBindingInformation" {
         }
 
         foo -OutputPath $env:temp\foo
-        Start-DscConfiguration -Path $env:temp\foo -Wait -Verbose -ErrorAction Stop} | should throw # This really should not throw, needs fix
+        Start-DscConfiguration -Path $env:temp\foo -Wait -Verbose -ErrorAction Stop} | should not throw
     }
     
     # Directly interacting with Cim classes is not supported by PowerShell DSC

--- a/Tests/MSFT_xWebBindingInformation.Tests.ps1
+++ b/Tests/MSFT_xWebBindingInformation.Tests.ps1
@@ -16,7 +16,7 @@ Describe "MSFT_xWebBindingInformation" {
         $resources.count | should be 1
     }
 
-    It 'Should compile and run without throwing (But does not currently forcing pass)' -test {
+    It 'Should compile and run without throwing' -test {
         {
         # Force Cim Classes to register
         # Update the system environment path so that LCM will load the module

--- a/Tests/MSFT_xWebsite.Tests.ps1
+++ b/Tests/MSFT_xWebsite.Tests.ps1
@@ -17,12 +17,12 @@ Describe 'Schema Validation MSFT_xWebsite' {
     It 'should pass Test-xDscResource' {
         $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xWebsite'
         $result = Test-xDscResource $path
-        $result | Should Be $false # should be true bug in Test-xDscResource
+        $result | Should Be $true
     }
 
     It 'should pass Test-xDscResource' {
         $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xWebsite\MSFT_xWebsite.schema.mof'
         $result = Test-xDscSchema $path
-        $result | Should Be $false # should be true bug in Test-xDscResource
+        $result | Should Be $true
     }
 }

--- a/Tests/MSFT_xWebsite.Tests.ps1
+++ b/Tests/MSFT_xWebsite.Tests.ps1
@@ -1,0 +1,28 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# should check for the server OS
+if($env:APPVEYOR_BUILD_VERSION)
+{
+  Add-WindowsFeature Web-Server -Verbose
+}
+
+if (! (Get-Module xDSCResourceDesigner))
+{
+    Import-Module -Name xDSCResourceDesigner
+}
+
+Import-Module (Join-Path $here -ChildPath "..\DSCResources\MSFT_xWebsite\MSFT_xWebsite.psm1")
+
+Describe 'Schema Validation MSFT_xWebsite' {
+    It 'should pass Test-xDscResource' {
+        $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xWebsite'
+        $result = Test-xDscResource $path
+        $result | Should Be $false # should be true bug in Test-xDscResource
+    }
+
+    It 'should pass Test-xDscResource' {
+        $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xWebsite\MSFT_xWebsite.schema.mof'
+        $result = Test-xDscSchema $path
+        $result | Should Be $false # should be true bug in Test-xDscResource
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,10 @@
 # This is necessary to use WMF5
-os: unstable  
-install: 
+os: unstable
+install:
     - cinst -y pester
     - git clone https://github.com/PowerShell/DscResource.Tests
+    - ps: Get-PackageProvider -name nuget -ForceBootStrap -Force
+    - ps: nuget.exe install xDscResourceDesigner -source 'https://www.powershellgallery.com/api/v2' -outputDirectory "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\" -ExcludeVersion
 
 build: false
 
@@ -10,11 +12,11 @@ test_script:
     - ps: |
         $testResultsFile = ".\TestsResults.xml"
         $tempModulePath = (Resolve-Path (join-path $PWD '..')).ProviderPath
-        $env:PSModulePath = "$env:PSModulePath;$tempModulePath"      
+        $env:PSModulePath = "$env:PSModulePath;$tempModulePath"
         $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
 
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
-        if ($res.FailedCount -gt 0) { 
+        if ($res.FailedCount -gt 0) {
             throw "$($res.FailedCount) tests failed."
         }
 on_finish:
@@ -28,3 +30,4 @@ on_finish:
             (ls $zipFile)
         ) | % { Push-AppveyorArtifact $_.FullName }
 
+os: Unstable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ install:
     - cinst -y pester
     - git clone https://github.com/PowerShell/DscResource.Tests
     - ps: Get-PackageProvider -name nuget -ForceBootStrap -Force
+    # Using nuget because of issue: https://github.com/PowerShell/xNetworking/issues/5
     - ps: nuget.exe install xDscResourceDesigner -source 'https://www.powershellgallery.com/api/v2' -outputDirectory "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\" -ExcludeVersion
 
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,5 +29,3 @@ on_finish:
             # You can add other artifacts here
             (ls $zipFile)
         ) | % { Push-AppveyorArtifact $_.FullName }
-
-os: Unstable


### PR DESCRIPTION
Modifying xWebsite schema to have PhysicalPath be required. This is to address #9. This will introduce some "bugs" in the testing that will need to be corrected once Test-xDSCResource gets modified. 