### PR TITLE
Supporting Server Name Indication

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -66,6 +66,7 @@ function Get-TargetResource
                 HostName              = $BindingObject.Hostname
                 CertificateThumbprint = $BindingObject.CertificateThumbprint
                 CertificateStoreName  = $BindingObject.CertificateStoreName
+                SSLFlags              = $BindingObject.SSLFlags
             } -ClientOnly
         }
 
@@ -88,10 +89,10 @@ function Get-TargetResource
     return @{
         Name            = $Website.Name
         Ensure          = $ensureResult
-        PhysicalPath    = $Website.physicalPath
-        State           = $Website.state
-        ID              = $Website.id
-        ApplicationPool = $Website.applicationPool
+        PhysicalPath    = $Website.PhysicalPath
+        State           = $Website.State
+        ID              = $Website.ID
+        ApplicationPool = $Website.ApplicationPool
         BindingInfo     = $CimBindings
         DefaultPage     = $allDefaultPage
     }
@@ -648,6 +649,12 @@ function Test-WebsiteBindings
                         $BindingNeedsUpdating = $true
                         break
                     }
+
+                    if([string]$ActualBinding.SSLFlags -ne [string]$binding.CimInstanceProperties['SSLFlags'].Value)
+                    {
+                        $BindingNeedsUpdating = $true
+                        break
+                    }
                 }
                 else
                 {
@@ -701,6 +708,7 @@ function Update-WebsiteBinding
         $HostHeader = $binding.CimInstanceProperties['HostName'].Value
         $CertificateThumbprint = $binding.CimInstanceProperties['CertificateThumbprint'].Value
         $CertificateStoreName = $binding.CimInstanceProperties['CertificateStoreName'].Value
+        $SSLFlags = $binding.CimInstanceProperties['SSLFlags'].Value
 
         $bindingParams = @{}
         $bindingParams.Add('-Name', $Name)
@@ -730,6 +738,11 @@ function Update-WebsiteBinding
         if($HostHeader -ne $null)
         {
             $bindingParams.Add('-HostHeader', $HostHeader)
+        }
+
+        if(-not [string]::IsNullOrEmpty($SSLFlags))
+        {
+            $bindingParams.Add('-SSLFlags', $SSLFlags)
         }
 
         try
@@ -798,8 +811,9 @@ function Get-WebBindingObject
         IPAddress             = $IPAddress
         Port                  = $Port
         HostName              = $HostName
-        CertificateThumbprint = $BindingInfo.CertificateHash
+        CertificateThumbprint = $BindingInfo.CertificateThumbprint
         CertificateStoreName  = $BindingInfo.CertificateStoreName
+        sslFlags              = $BindingInfo.sslFlags
     }
 }
 

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
@@ -7,6 +7,7 @@ Class MSFT_xWebBindingInformation
     [write]String HostName;
     [write]String CertificateThumbprint;
     [write,ValueMap{"My", "WebHosting"},Values{"My", "WebHosting"}] string CertificateStoreName;
+    [write] string SSLFlags;
 };
 
 

--- a/Tests/MSFT_xWebsite.Tests.ps1
+++ b/Tests/MSFT_xWebsite.Tests.ps1
@@ -296,7 +296,7 @@ InModuleScope MSFT_xWebsite {
                 bindingInformation = '127.0.0.1:443:MockHostName'
                 protocol           = 'https'
                 SslFlags           = 1
-                CertificateThumbprint = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
+                CertificateHash = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
                 CertificateStoreName  = 'My'
             }
 
@@ -356,7 +356,7 @@ InModuleScope MSFT_xWebsite {
                 $result.BindingInfo.Protocol              | Should Be $BindingInfo.Protocol
                 $result.BindingInfo.IPAddress             | Should Be $BindingObject.IPAddress
                 $result.BindingInfo.HostName              | Should Be $BindingObject.HostName
-                $result.BindingInfo.CertificateThumbprint | Should Be $BindingInfo.CertificateThumbprint
+                $result.BindingInfo.CertificateThumbprint | Should Be $BindingInfo.Certificatehash
                 $result.BindingInfo.CertificateStoreName  | Should Be $BindingInfo.CertificateStoreName
                 $result.BindingInfo.SSLFlags              | Should Be $BindingInfo.SSLFlags
             }
@@ -703,7 +703,7 @@ InModuleScope MSFT_xWebsite {
             $BindingInfo = [PSCustomObject] @{
                 bindingInformation     = '127.0.0.1:443:MockHostName'
                 protocol               = 'https'
-                CertificateThumbprint  = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
+                CertificateHash  = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
                 CertificateStoreName   = 'My'
                 SSLFlags               = '1'
             }
@@ -743,7 +743,7 @@ InModuleScope MSFT_xWebsite {
             $BindingInfo = [PSCustomObject] @{
                 bindingInformation    = '[0:0:0:0:0:0:0:1]:443:MockHostName'
                 protocol              = 'https'
-                CertificateThumbprint = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
+                CertificateHash = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
                 CertificateStoreName  = 'My'
                 SSLFlags              = '1'
             }
@@ -877,6 +877,7 @@ InModuleScope MSFT_xWebsite {
             Protocol  = $BindingObject.Protocol
             IPAddress = $BindingObject.IPaddress
             HostName  = $BindingObject.Hostname
+            SSLFlags  = $BindingObject.SSLFlags
         } -ClientOnly
 
         Context 'Confirm-PortIPHostisUnique returns false' {
@@ -989,6 +990,7 @@ InModuleScope MSFT_xWebsite {
                 HostName              = 'MockHostName'
                 CertificateThumbprint = ''
                 CertificateStoreName  = ''
+                SSLFlags              = 0
             }
 
             $mockBindingIP = New-CimInstance -ClassName MSFT_xWebBindingInformation -Namespace root/microsoft/Windows/DesiredStateConfiguration -Property @{
@@ -1063,8 +1065,8 @@ InModuleScope MSFT_xWebsite {
                 Protocol              = 'http'
                 IPAddress             = '127.0.0.1'
                 HostName              = 'MockHostName'
-                CertificateThumbprint = ''
-                CertificateStoreName  = 'DDDDD'
+                CertificateThumbprint = '1234560215616'
+                CertificateStoreName  = 'WebHosting'
             }
 
             Mock Confirm-PortIPHostisUnique {return $true}
@@ -1077,6 +1079,27 @@ InModuleScope MSFT_xWebsite {
             }
         }
 
+        Context 'CertificateStoreName is incorrect and no thumbrpint is specified' {
+            $badBindingObject = @{
+                Port                  = 80
+                Protocol              = 'http'
+                IPAddress             = '127.0.0.1'
+                HostName              = 'MockHostName'
+                CertificateThumbprint = ''
+                CertificateStoreName  = 'WebHosting'
+                SSLFlags = 0
+            }
+
+            Mock Confirm-PortIPHostisUnique {return $true}
+            Mock Get-WebBinding {return $BindingObject}
+            Mock Get-Website {return $MockSite}
+            Mock Get-WebBindingObject { return $badBindingObject }
+
+            It 'should return false' {
+                Test-WebsiteBindings -Name $BindingObject.hostname -BindingInfo $MockBinding | Should be $false
+            }
+        }
+
         Context 'SSLFlags is incorrect' {
             $badBindingObject = @{
                 Port                  = 80
@@ -1085,7 +1108,7 @@ InModuleScope MSFT_xWebsite {
                 HostName              = 'MockHostName'
                 CertificateThumbprint = ''
                 CertificateStoreName  = ''
-                SSLFlags              = 0
+                SSLFlags              = 1
             }
 
             Mock Confirm-PortIPHostisUnique {return $true}
@@ -1106,6 +1129,7 @@ InModuleScope MSFT_xWebsite {
                 HostName              = 'MockHostName'
                 CertificateThumbprint = ''
                 CertificateStoreName  = ''
+                SSLFlags              = 0
             }
 
             Mock Confirm-PortIPHostisUnique {return $true}

--- a/Tests/MSFT_xWebsite.Tests.ps1
+++ b/Tests/MSFT_xWebsite.Tests.ps1
@@ -286,15 +286,18 @@ InModuleScope MSFT_xWebsite {
 
         Context 'Single website exists' {
             $BindingObject = [PSCustomObject] @{
-                Protocol  = 'http'
+                Protocol  = 'https'
                 IPAddress = '127.0.0.1'
-                Port      = '80'
+                Port      = 443
                 HostName  = 'MockHostName'
             }
 
             $BindingInfo = [PSCustomObject] @{
-                bindingInformation = '127.0.0.1:80:*'
-                protocol           = 'http'
+                bindingInformation = '127.0.0.1:443:MockHostName'
+                protocol           = 'https'
+                SslFlags           = 1
+                CertificateThumbprint = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
+                CertificateStoreName  = 'My'
             }
 
             $Website = [PSCustomObject] @{
@@ -311,7 +314,9 @@ InModuleScope MSFT_xWebsite {
             }
 
             Mock Get-ItemProperty {
-                return $BindingInfo
+                return @{
+                    collection = $BindingInfo
+                }
             }
 
             Mock Get-WebConfiguration {
@@ -344,6 +349,16 @@ InModuleScope MSFT_xWebsite {
 
             It 'should return the PhysicalPath' {
                 $result.PhysicalPath | Should Be 'C:\SomePath'
+            }
+
+            It 'should return the correct bindings' {
+                $result.BindingInfo.Port                  | Should Be $BindingObject.Port
+                $result.BindingInfo.Protocol              | Should Be $BindingInfo.Protocol
+                $result.BindingInfo.IPAddress             | Should Be $BindingObject.IPAddress
+                $result.BindingInfo.HostName              | Should Be $BindingObject.HostName
+                $result.BindingInfo.CertificateThumbprint | Should Be $BindingInfo.CertificateThumbprint
+                $result.BindingInfo.CertificateStoreName  | Should Be $BindingInfo.CertificateStoreName
+                $result.BindingInfo.SSLFlags              | Should Be $BindingInfo.SSLFlags
             }
 
             It 'should return the State' {
@@ -686,10 +701,11 @@ InModuleScope MSFT_xWebsite {
 
         Context 'IPv4 SSL Certificate is passed' {
             $BindingInfo = [PSCustomObject] @{
-                bindingInformation   = '127.0.0.1:443:MockHostName'
-                protocol             = 'https'
-                CertificateHash      = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
-                CertificateStoreName = 'My'
+                bindingInformation     = '127.0.0.1:443:MockHostName'
+                protocol               = 'https'
+                CertificateThumbprint  = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
+                CertificateStoreName   = 'My'
+                SSLFlags               = '1'
             }
 
             $result = Get-WebBindingObject -BindingInfo $BindingInfo
@@ -717,14 +733,19 @@ InModuleScope MSFT_xWebsite {
             It 'should return the store' {
                 $result.CertificateStoreName | Should Be 'My'
             }
+
+            It 'should return the SSLFlags' {
+                $result.SSLFlags | Should Be '1'
+            }
         }
 
         Context 'IPv6 SSL Certificate is passed' {
             $BindingInfo = [PSCustomObject] @{
-                bindingInformation   = '[0:0:0:0:0:0:0:1]:443:MockHostName'
-                protocol             = 'https'
-                CertificateHash      = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
-                CertificateStoreName = 'My'
+                bindingInformation    = '[0:0:0:0:0:0:0:1]:443:MockHostName'
+                protocol              = 'https'
+                CertificateThumbprint = '3E09CCC8DFDCB8E3D4A83CFF164CC4754C25E9E5'
+                CertificateStoreName  = 'My'
+                SSLFlags              = '1'
             }
 
             $result = Get-WebBindingObject -BindingInfo $BindingInfo
@@ -751,6 +772,10 @@ InModuleScope MSFT_xWebsite {
 
             It 'should return the store' {
                 $result.CertificateStoreName | Should Be 'My'
+            }
+
+            It 'should return the SSLFlags' {
+                $result.SSLFlags | Should Be '1'
             }
         }
     }
@@ -844,6 +869,7 @@ InModuleScope MSFT_xWebsite {
             HostName              = 'MockHostName'
             CertificateThumbprint = ''
             CertificateStoreName  = ''
+            SSLFlags              = 0
         }
 
         $mockBinding = New-CimInstance -ClassName MSFT_xWebBindingInformation -Namespace root/microsoft/Windows/DesiredStateConfiguration -Property @{
@@ -1051,6 +1077,27 @@ InModuleScope MSFT_xWebsite {
             }
         }
 
+        Context 'SSLFlags is incorrect' {
+            $badBindingObject = @{
+                Port                  = 80
+                Protocol              = 'http'
+                IPAddress             = '127.0.0.1'
+                HostName              = 'MockHostName'
+                CertificateThumbprint = ''
+                CertificateStoreName  = ''
+                SSLFlags              = 0
+            }
+
+            Mock Confirm-PortIPHostisUnique {return $true}
+            Mock Get-WebBinding {return $BindingObject}
+            Mock Get-Website {return $MockSite}
+            Mock Get-WebBindingObject { return $badBindingObject }
+
+            It 'should return true' {
+                Test-WebsiteBindings -Name $BindingObject.hostname -BindingInfo $MockBinding | Should be $true
+            }
+        }
+
         Context 'Everything is the same' {
             $badBindingObject = @{
                 Port                  = 80
@@ -1080,16 +1127,17 @@ InModuleScope MSFT_xWebsite {
             ID              = 1
             State           = 'Started'
             ApplicationPool = 'MockPool'
-            BindingInformation = '127.0.0.1:80:'
+            BindingInformation = '127.0.0.1:443:'
         }
 
         $BindingObject = @{
-            Port                  = 80
-            Protocol              = 'http'
+            Port                  = 443
+            Protocol              = 'https'
             IPAddress             = '127.0.0.1'
             HostName              = 'MockHostName'
-            CertificateThumbprint = ''
-            CertificateStoreName  = ''
+            CertificateThumbprint = '1234561651481561891481654891651'
+            CertificateStoreName  = 'MY'
+            SSLFlags              = 1
         }
 
         $mockBinding = New-CimInstance -ClassName MSFT_xWebBindingInformation -Namespace root/microsoft/Windows/DesiredStateConfiguration -Property @{
@@ -1097,6 +1145,7 @@ InModuleScope MSFT_xWebsite {
             Protocol  = $BindingObject.Protocol
             IPAddress = $BindingObject.IPaddress
             HostName  = $BindingObject.Hostname
+            SSLFlags  = $BindingObject.SSLFlags
         } -ClientOnly
 
         Context 'expected behavior' {
@@ -1130,6 +1179,10 @@ InModuleScope MSFT_xWebsite {
 
             It 'should use the right Hostheader' {
                 $result.Hostheader | Should be $mockBinding.HostName
+            }
+
+            It 'should use the right SSLFlags' {
+                $result.SslFlags | Should be $mockBinding.SslFlags
             }
         }
 


### PR DESCRIPTION
This should fix #31. BUT I'm running into some strangeness where when I run this I run Set-TargetResource every time.  From what I've been able to tell the problem boils down to line 594 when Get-WebBinding runs.

I'm seeing the following when I run DSC:
````
VERBOSE: [web]: LCM:  [ Start  Resource ]  [[xWebsite]DefaultSite]
VERBOSE: [web]: LCM:  [ Start  Test     ]  [[xWebsite]DefaultSite]
VERBOSE: [web]:                            [[xWebsite]DefaultSite] Getting Web Binding: Default Web Site
VERBOSE: [web]: LCM:  [ End    Test     ]  [[xWebsite]DefaultSite]  in 0.9690 seconds.
VERBOSE: [web]: LCM:  [ Start  Set      ]  [[xWebsite]DefaultSite]
VERBOSE: [web]:                            [[xWebsite]DefaultSite] Getting Web Binding: Default Web Site
VERBOSE: [web]: LCM:  [ End    Set      ]  [[xWebsite]DefaultSite]  in 1.0000 seconds.
VERBOSE: [web]: LCM:  [ End    Resource ]  [[xWebsite]DefaultSite]
````

What I'm expecting to see is

````
VERBOSE: [web]: LCM:  [ Start  Resource ]  [[xWebsite]DefaultSite]
VERBOSE: [web]: LCM:  [ Start  Test     ]  [[xWebsite]DefaultSite]
VERBOSE: [web]:                            [[xWebsite]DefaultSite] Getting Web Binding: Default Web Site
-->VERBOSE: [web]:                            [[xWebsite]DefaultSite] Actual Bindings: 80 * http
VERBOSE: [web]: LCM:  [ End    Test     ]  [[xWebsite]DefaultSite]  in 0.9690 seconds.
--> VERBOSE: [web]: LCM:  [ Skip  Set      ]  [[xWebsite]DefaultSite]
VERBOSE: [web]: LCM:  [ End    Set      ]  [[xWebsite]DefaultSite]  in 1.0000 seconds.
VERBOSE: [web]: LCM:  [ End    Resource ]  [[xWebsite]DefaultSite]
````
My config boils down to this:

````
instance of MSFT_xWebBindingInformation as $MSFT_xWebBindingInformation1ref
{
 HostName = NULL;
 Port = 80;
 IPAddress = "*";
 Protocol = "http";
};

instance of MSFT_xWebsite as $MSFT_xWebsite1ref
{
ResourceID = "[xWebsite]DefaultSite";
 PhysicalPath = "C:\\inetpub\\wwwroot";
 State = "Started";
 Ensure = "Present";
 SourceInfo = "C:\\somepath\\SourceInfo.psm1::90::17::xWebsite";
 Name = "Default Web Site";
 ModuleName = "xWebAdministration";
 BindingInfo = {
    $MSFT_xWebBindingInformation1ref
};

````

I am super confused, can anyone clue me into what the hell is going on?