### PR TITLE
Change Test Get-Website to match other function

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -402,7 +402,9 @@ function Test-TargetResource
         Throw 'Please ensure that WebAdministration module is installed.'
     }
 
-    $Website = Get-Website -Name $Name
+    $Website = Get-Website | Where-Object -FilterScript {
+        $_.Name -eq $Name
+    }
     $Stop = $true
 
     Do


### PR DESCRIPTION
Fixes errors seen on 2008 r2 server when site is not initially created.