### PR TITLE
Update MSFT_xWebsite.psm1 - SSL for hostheaders

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -759,7 +759,7 @@ function Update-WebsiteBinding
         if($HostHeader -ne $null)
         {
             $bindingParams.Add('-HostHeader', $HostHeader)
-			$UseHostHeader = $true
+            $UseHostHeader = $true
         }
 
         if(-not [string]::IsNullOrWhiteSpace($SSLFlags))
@@ -790,7 +790,7 @@ function Update-WebsiteBinding
                 if ($UseHostHeader -eq $true)
                 {
                     $NewWebbinding = Get-WebBinding -Name $Name -Port $Port -HostHeader $HostHeader
-                    $NewWebbinding.AddSslCertificate($CertificateThumbprint, $CertificateStoreName)                
+                    $NewWebbinding.AddSslCertificate($CertificateThumbprint, $CertificateStoreName)
                 }
                 Else{
                     $NewWebbinding = Get-WebBinding -Name $Name -Port $Port

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -718,6 +718,9 @@ function Update-WebsiteBinding
     #Need to clear the bindings before we can create new ones
     Clear-ItemProperty -Path IIS:\Sites\$Name -Name bindings -ErrorAction Stop
 
+    #Need to clear $UseHostheader flag for multiple ssl bindings per site
+    $UseHostHeader = $false
+
     foreach($binding in $BindingInfo)
     {
         $Protocol = $binding.CimInstanceProperties['Protocol'].Value
@@ -756,6 +759,7 @@ function Update-WebsiteBinding
         if($HostHeader -ne $null)
         {
             $bindingParams.Add('-HostHeader', $HostHeader)
+			$UseHostHeader = $true
         }
 
         if(-not [string]::IsNullOrWhiteSpace($SSLFlags))
@@ -783,8 +787,15 @@ function Update-WebsiteBinding
         {
             if ( -not [string]::IsNullOrWhiteSpace($CertificateThumbprint) )
             {
-                $NewWebbinding = Get-WebBinding -Name $Name -Port $Port
-                $NewWebbinding.AddSslCertificate($CertificateThumbprint, $CertificateStoreName)
+                if ($UseHostHeader -eq $true)
+                {
+                    $NewWebbinding = Get-WebBinding -Name $Name -Port $Port -HostHeader $HostHeader
+                    $NewWebbinding.AddSslCertificate($CertificateThumbprint, $CertificateStoreName)                
+                }
+                Else{
+                    $NewWebbinding = Get-WebBinding -Name $Name -Port $Port
+                    $NewWebbinding.AddSslCertificate($CertificateThumbprint, $CertificateStoreName)
+                }
             }
         }
         catch

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -893,5 +893,4 @@ function Write-Log
         "${date}: $message" | Out-File -Append -FilePath $filename
     }
 }
-
 #endregion


### PR DESCRIPTION
The current xWebsite did not seem to accommodate hostheaders or multiple SSL on one site via hostheaders. The code is just adding a UseHostHeader flag that changes the Get-WebBinding to check for hostheader when binding to hostheadered SSL. This does not check if the SSLFlags setting is set correctly. 
This is my first time to contribute to GitHub, or opensource in general for that matter. So, hopefully I am doing this right.