### PR TITLE
Fixed xWebsite set logging directory on first run

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -294,6 +294,13 @@ function Set-TargetResource
                     $Website = New-Website @psboundparameters
                 }
                 $Result = Stop-Website $Website.name -ErrorAction Stop
+                
+                # Set website logging directory
+                Write-Verbose("Updating LogPath $LogPath");
+                if($LogPath -ne $null)
+                {
+                    Set-ItemProperty IIS:\Sites\$Name -name logFile.directory -value $LogPath
+                } 
 
                 #Clear default bindings if new bindings defined and are different
                 if($BindingInfo -ne $null)


### PR DESCRIPTION
The section of code which sets the website log directory was only executed when checking the desired state of an existing website and was not when creating new websites.

This resulted in the all sites using the default logging path until the configuration is applied for a second time which is an issue when using a push configuration mode.