### PR TITLE
Moving AppVoyer to WMF5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+DSCResource.Tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 #      environment configuration  #
 #---------------------------------#
 # This is necessary to use WMF5
-os: WMF 5.0
+os: WMF 5
 version: 1.8.{build}.0
 install:
   - cinst -y pester --version 3.3.13

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,12 @@
 #      environment configuration  #
 #---------------------------------#
 # This is necessary to use WMF5
-os: unstable
+os: WMF 5.0
 version: 1.8.{build}.0
 install:
   - cinst -y pester --version 3.3.13
   - git clone https://github.com/PowerShell/DscResource.Tests
+  - ps: Install-WindowsFeature -IncludeAllSubFeature -IncludeManagementTools -Name 'Web-Server'
   - ps: Push-Location
   - cd DscResource.Tests
   - ps: Import-Module .\TestHelper.psm1 -force

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,3 +63,4 @@ deploy_script:
           Write-Host "Pushing package $_ as Appveyor artifact"
           Push-AppveyorArtifact $_
         }
+


### PR DESCRIPTION
Moving AppVoyer to WMF5 and updating .gitignore to ignore DSCResource.Tests which we will be moving to as its the new standard of testing the system.