### PR TITLE
xWebVirtualDirectory resource WebApplication accepts empty strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Currently, only FastCgiModule is supported.
 ### xWebVirtualDirectory
 
 * **Website**: Name of website with which virtual directory is associated
-* **WebApplication**:  Web application name for the virtual directory
+* **WebApplication**:  The name of the containing web application or an empty string for the containing website
 * **PhysicalPath**: The path to the files that compose the virtual directory
 * **Name**: The name of the virtual directory
 * **Ensure**: Ensures if the virtual directory is Present or Absent.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Currently, only FastCgiModule is supported.
 * Fixed script analyzer failures in examples
 * **xWebsite**: Fixed an issue in BindingInfo validation that caused multiple bindings with the same port and protocol treated as invalid.
 * Changed PhysicalPath in xWebsite to be optional
+* Changed WebApplication in xWebVirtualDirectory to accept empty strings for referring to the top-level IIS site
 
 ### 1.9.0.0
 

--- a/Tests/Unit/MSFT_xWebVirtualDirectory.tests.ps1
+++ b/Tests/Unit/MSFT_xWebVirtualDirectory.tests.ps1
@@ -44,7 +44,7 @@ try
             }
             Context 'Directory is Present and PhysicalPath is Correct' {
                 It 'should return true' {
-                    Mock Get-WebVirtualDirectoryInternal { return $virtualDir }
+                    Mock Get-WebVirtualDirectory { return $virtualDir }
                     Test-TargetResource -Website $MockSite.Website -WebApplication $MockSite.WebApplication -Name $MockSite.Name -PhysicalPath $MockSite.PhysicalPath -Ensure $MockSite.Ensure | Should Be $true
                 }
             }
@@ -57,7 +57,7 @@ try
                         Count = 1
                     }
 
-                    Mock Get-WebVirtualDirectoryInternal { return $virtualDir }
+                    Mock Get-WebVirtualDirectory { return $virtualDir }
                     Test-TargetResource -Website $MockSite.Website -WebApplication $MockSite.WebApplication -Name $MockSite.Name -PhysicalPath $MockSite.PhysicalPath -Ensure $MockSite.Ensure | Should Be $false
                 }
             }
@@ -70,7 +70,7 @@ try
                         Count = 1
                     }
 
-                    Mock Get-WebVirtualDirectoryInternal { return $virtualDir }
+                    Mock Get-WebVirtualDirectory { return $virtualDir }
                     Test-TargetResource -Website $MockSite.Website -WebApplication $MockSite.WebApplication -Name $MockSite.Name -PhysicalPath $MockSite.PhysicalPath -Ensure $MockSite.Ensure | Should Be $false
                 }
             }
@@ -87,7 +87,7 @@ try
                         Ensure = 'Absent'
                     }
                     Mock Test-Dependancies { return $null }
-                    Mock Get-WebVirtualDirectoryInternal { return $null }
+                    Mock Get-WebVirtualDirectory { return $null }
                     $result = Get-TargetResource -Website $returnSite.Website -WebApplication $returnSite.WebApplication -Name $returnSite.Name -PhysicalPath $returnSite.PhysicalPath
 
                     $result.Name | Should Be $returnSite.Name
@@ -113,7 +113,7 @@ try
                 }
 
                 Mock Test-Dependancies { return $null }
-                Mock Get-WebVirtualDirectoryInternal { return $returnObj }
+                Mock Get-WebVirtualDirectory { return $returnObj }
                 $result = Get-TargetResource -Website $returnSite.Website -WebApplication $returnSite.WebApplication -Name $returnSite.Name -PhysicalPath $returnSite.PhysicalPath
 
                 $result.Name | Should Be $returnSite.Name
@@ -152,7 +152,7 @@ try
                     }
 
                     Mock Test-Dependancies { return $null }
-                    Mock Get-WebVirtualDirectoryInternal { return $mockSite }
+                    Mock Get-WebVirtualDirectory { return $mockSite }
                     Mock Set-ItemProperty { return $null }
                     $null = Set-TargetResource -Website $mockSite.Website -WebApplication $mockSite.WebApplication -Name $mockSite.Name -PhysicalPath $mockSite.PhysicalPath -Ensure 'Present'
                     Assert-MockCalled Set-ItemProperty -Exactly 1
@@ -173,37 +173,6 @@ try
                     Mock Remove-WebVirtualDirectory { return $null }
                     $null = Set-TargetResource -Website $mockSite.Website -WebApplication $mockSite.WebApplication -Name $mockSite.Name -PhysicalPath $mockSite.PhysicalPath -Ensure 'Absent'
                     Assert-MockCalled Remove-WebVirtualDirectory -Exactly 1
-                }
-            }
-        }
-
-        Describe "$global:DSCResourceName\Get-WebVirtualDirectoryInternal" {
-            $MockSite = @{
-                Website        = 'contoso.com'
-                WebApplication = 'contosoapp'
-                Name           = 'shared_directory'
-                PhysicalPath   = 'C:\inetpub\wwwroot\shared'
-                Ensure         = 'Present'
-            }
-
-            Context 'Test-ApplicationExists returns false' {
-                Mock Test-ApplicationExists { return $false }
-                Mock Get-WebVirtualDirectory { return $Name }
-                It 'return the correct string' {
-                    Get-WebVirtualDirectoryInternal -Name $MockSite.Name -Site $MockSite.Website -Application $MockSite.WebApplication | should be "$($MockSite.WebApplication)/$($MockSite.Name)"
-                }
-            }
-
-            Context 'Test-ApplicationExists returns true' {
-                $returnObj = @{
-                    'Name' = $MockSite.Name
-                    'Physical Path' = $MockSite.PhysicalPath
-                }
-                Mock Test-ApplicationExists { return $false }
-                Mock Get-WebVirtualDirectory { return $returnObj }
-
-                It 'return the correct string' {
-                    Get-WebVirtualDirectoryInternal -Name $MockSite.Name -Site $MockSite.Website -Application $MockSite.WebApplication | should be $returnObj
                 }
             }
         }

--- a/Tests/Unit/MSFT_xWebVirtualDirectory.tests.ps1
+++ b/Tests/Unit/MSFT_xWebVirtualDirectory.tests.ps1
@@ -176,14 +176,6 @@ try
                 }
             }
         }
-
-        Describe "$global:DSCResourceName\Get-CompositeName" {
-            Context 'data is passed in' {
-                It 'should return the correct string' {
-                    Get-CompositeName -Name 'Name' -Application 'Application' | should be 'Application/Name'
-                }
-            }
-        }
     }
 }
 finally

--- a/Tests/Unit/MSFT_xWebVirtualDirectory.tests.ps1
+++ b/Tests/Unit/MSFT_xWebVirtualDirectory.tests.ps1
@@ -177,30 +177,6 @@ try
             }
         }
 
-        Describe "$global:DSCResourceName\Test-ApplicationExists" {
-            $MockSite = @{
-                Website        = 'contoso.com'
-                WebApplication = 'contosoapp'
-                Name           = 'shared_directory'
-                PhysicalPath   = 'C:\inetpub\wwwroot\shared'
-                Ensure         = 'Present'
-            }
-
-            Context 'Get-WebApplication returns a value' {
-                It 'should return true' {
-                    Mock Get-WebApplication { return @{Count = 1} }
-                    Test-ApplicationExists -Site $MockSite.Website -Application $MockSite.WebApplication | should be $true
-                }
-            }
-
-            Context 'Get-WebApplication returns no value' {
-                It 'should return false' {
-                    Mock Get-WebApplication { return @{Count = 0} }
-                    Test-ApplicationExists -Site $MockSite.Website -Application $MockSite.WebApplication | should be $false
-                }
-            }
-        }
-
         Describe "$global:DSCResourceName\Get-CompositeName" {
             Context 'data is passed in' {
                 It 'should return the correct string' {


### PR DESCRIPTION
The WebApplication parameter now accepts empty strings which refer to site-wide virtual directories instead of application-specific ones. This references #57.

@tysonjhayes I have a few questions regarding this new functionality. First, do you think it would be a good idea to provide a default value of `[string]::Empty` for the `WebApplication` parameter so it really is optional? Second, I see there are unit tests but I'm not sure how to run them locally so I can fix anything I might have broken. Could you maybe point me in the right direction?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/95)
<!-- Reviewable:end -->
