### PR TITLE
got rid of git dependencies in tests

### DIFF
--- a/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
@@ -8,10 +8,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Integration/MSFT_xIISHandler.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIISHandler.Integration.Tests.ps1
@@ -8,10 +8,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Integration/MSFT_xIISMimeTypeMapping.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIISMimeTypeMapping.Integration.Tests.ps1
@@ -8,10 +8,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Integration/MSFT_xWebAppPool.Integration.tests.ps1
+++ b/Tests/Integration/MSFT_xWebAppPool.Integration.tests.ps1
@@ -22,10 +22,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Integration/MSFT_xWebAppPoolDefaults.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebAppPoolDefaults.Integration.Tests.ps1
@@ -8,10 +8,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
@@ -8,10 +8,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Integration/MSFT_xWebsiteDefaults.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebsiteDefaults.Integration.Tests.ps1
@@ -8,10 +8,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Unit/MSFT_xIISFeatureDelegation.tests.ps1
+++ b/Tests/Unit/MSFT_xIISFeatureDelegation.tests.ps1
@@ -8,10 +8,7 @@ $global:DSCResourceName = 'MSFT_xIISFeatureDelegation'
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Unit/MSFT_xIISHandler.tests.ps1
+++ b/Tests/Unit/MSFT_xIISHandler.tests.ps1
@@ -8,10 +8,7 @@ $global:DSCResourceName = 'MSFT_xIISHandler'
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Unit/MSFT_xSSLSettings.Tests.ps1
+++ b/Tests/Unit/MSFT_xSSLSettings.Tests.ps1
@@ -8,10 +8,7 @@ $global:DSCResourceName = 'MSFT_xSSLSettings'
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Unit/MSFT_xWebAppPool.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebAppPool.Tests.ps1
@@ -13,10 +13,7 @@ $global:DSCResourceName = 'MSFT_xWebAppPool'
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Unit/MSFT_xWebApplication.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebApplication.Tests.ps1
@@ -8,10 +8,7 @@ $global:DSCResourceName = 'MSFT_xWebApplication'
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Unit/MSFT_xWebVirtualDirectory.tests.ps1
+++ b/Tests/Unit/MSFT_xWebVirtualDirectory.tests.ps1
@@ -8,10 +8,7 @@ $global:DSCResourceName = 'MSFT_xWebVirtualDirectory'
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -8,10 +8,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource
 {
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
+
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `


### PR DESCRIPTION
Now, if a user downloads this module from the gallery (once these changes are published and part II below is implemented) they will not be forced to use git on their machine because part II of this fix will include manually downloading the DSCResource.Tests folder before publishing to the gallery