### PR TITLE
xWebsite updated to remove Unicode LRM char from CertificateThumbprint

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -722,7 +722,7 @@ function ConvertTo-WebBinding
                         $CertificateStoreName = $Binding.CertificateStoreName
                     }
 
-                    # Remove an invisible Unicode "LEFT-TO-RIGHT MARK" character
+                    # Remove the Left-to-Right Mark character
                     $CertificateHash = $Binding.CertificateThumbprint -replace '^\u200E'
 
                     $OutputObject.Add('certificateHash',      [String]$CertificateHash)

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -722,7 +722,10 @@ function ConvertTo-WebBinding
                         $CertificateStoreName = $Binding.CertificateStoreName
                     }
 
-                    $OutputObject.Add('certificateHash',      [String]$Binding.CertificateThumbprint)
+                    # Remove an invisible Unicode "LEFT-TO-RIGHT MARK" character
+                    $CertificateHash = $Binding.CertificateThumbprint -replace '^\u200E'
+
+                    $OutputObject.Add('certificateHash',      [String]$CertificateHash)
                     $OutputObject.Add('certificateStoreName', [String]$CertificateStoreName)
 
                     if ([Environment]::OSVersion.Version -ge '6.2')

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Currently, only FastCgiModule is supported.
         **passAnonymousToken**, **cpuSmpAffinitized**, **loadUserProfile**, **manualGroupMembership**, **pingingEnabled**, **setProfileEnvironment**,
         **orphanWorkerProcess**, **rapidFailProtection**, **disallowOverlappingRotation**, **disallowRotationOnConfigChange**.
     * Unit and integration tests updated.
+* **xWebsite** updated to remove invisible Unicode "LEFT-TO-RIGHT MARK" character from the **CertificateThumbprint** property value.
 
 ### 1.10.0.0
 


### PR DESCRIPTION
xWebsite updated to remove invisible Unicode "LEFT-TO-RIGHT MARK" character from the CertificateThumbprint property value.
Addresses #121.