### PR TITLE
Update MSFT_xWebsite.psm1; The site name should be passed in as argument for Test-AuthenticationInfo 

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -549,7 +549,7 @@ function Test-TargetResource
         }
 
         #Check AuthenticationInfo
-        if ($PSBoundParameters.ContainsKey('AuthenticationInfo') -and (-not (Test-AuthenticationInfo -Site $Website -AuthenticationInfo $AuthenticationInfo)))
+        if ($PSBoundParameters.ContainsKey('AuthenticationInfo') -and (-not (Test-AuthenticationInfo -Site $Name -AuthenticationInfo $AuthenticationInfo)))
         { 
             $InDesiredState = $false
             Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalseAuthenticationInfo)

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Currently, only FastCgiModule is supported.
 ## Versions
 
 ### Unreleased
+* **xWebsite** updates:
+    * Bugfix for #131 The site name should be passed in as argument for Test-AuthenticationInfo 
 
 ### 1.11.0.0
 


### PR DESCRIPTION
The site name should be passed in as argument. Otherwise the resource failes with the following error:
Filename: 
Error: Unrecognized configuration path 'MACHINE/WEBROOT/APPHOST/Microsoft.IIs.PowerShell.Framework.ConfigurationElement'
    + CategoryInfo          : NotSpecified: (:) [], CimException
    + FullyQualifiedErrorId : System.IO.FileNotFoundException,Microsoft.IIs.PowerShell.Provider.GetConfigurationPropertyCommand
    + PSComputerName        : vm2
 
VERBOSE: [VM2]:                            [[xWebsite]IpManWebsite] AuthenticationInfo is not in the desired state.
VERBOSE: [VM2]:                            [[xWebsite]IpManWebsite] The target resource is not in the desired state.
VERBOSE: [VM2]: LCM:  [ End    Test     ]  [[xWebsite]IpManWebsite]  in 0.7180 seconds.
The PowerShell DSC resource '[xWebsite]IpManWebsite' with SourceInfo '::269::13::xWebsite' threw one or more non-terminating errors while running the Test-TargetResource functionality. These errors 
are logged to the ETW channel called Microsoft-Windows-DSC/Operational. Refer to this channel for more details.
    + CategoryInfo          : InvalidOperation: (:) [], CimException
    + FullyQualifiedErrorId : NonTerminatingErrorFromProvider
    + PSComputerName        : vm2
 
The SendConfigurationApply function did not succeed.
    + CategoryInfo          : NotSpecified: (root/Microsoft/...gurationManager:String) [], CimException
    + FullyQualifiedErrorId : MI RESULT 1
    + PSComputerName        : vm2