### PR TITLE
Fixed application pool settings of WebApplication

### DIFF
--- a/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
+++ b/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
@@ -146,6 +146,7 @@ function Set-TargetResource
                 New-WebApplication -Site $Website -Name $Name `
                                    -PhysicalPath $PhysicalPath `
                                    -ApplicationPool $WebAppPool
+                $webApplication = Get-WebApplication -Site $Website -Name $Name
             }
 
             #Update Physical Path if required

--- a/README.md
+++ b/README.md
@@ -223,15 +223,22 @@ Currently, only FastCgiModule is supported.
     * LoglocalTimeRollover
     * LogFormat
 
-* Added **xWebApplication** integration tests
-* Added fixes to **xWebApplication**. Formatted resources to DSC StyleGuideLines, fixed logging statements, fixed incorrect Get-TargetResource param block, fixed Test-SslFlags validation, fixed unit test mocking of Test-SslFlags, added Ssl128 option to SslFlags
-
+* **xWebApplication** updates:
+    * Added integration tests and added option to SslFlags
+    * Fixed: 
+         * Formatted resources to DSC StyleGuideLines 
+         * Logging statements
+         * Incorrect Get-TargetResource param block
+         * Test-SslFlags validation
+         * Unit test mocking of Test-SslFlags
+    * Fixed: The changes of the application pool of WebApplication is applied correctly.
+	
 ### 1.11.0.0
 
 * **xWebAppPool** updates:
     * Bug fixes, error handling and input validation improvements.
-    * The resource was updated to ensure a specific state only for the explicitly specified properties.
     * The following properties were added: **idleTimeoutAction**, **logEventOnProcessModel**, **setProfileEnvironment**.
+    * The resource was updated to ensure a specific state only for the explicitly specified properties.
     * The type of the following properties was changed to **Boolean**: **autoStart**, **enable32BitAppOnWin64**, **enableConfigurationOverride**,
         **passAnonymousToken**, **cpuSmpAffinitized**, **loadUserProfile**, **manualGroupMembership**, **pingingEnabled**, **setProfileEnvironment**,
         **orphanWorkerProcess**, **rapidFailProtection**, **disallowOverlappingRotation**, **disallowRotationOnConfigChange**.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Currently, only FastCgiModule is supported.
          * Incorrect Get-TargetResource param block
          * Test-SslFlags validation
          * Unit test mocking of Test-SslFlags
-    * Fixed: The changes of the application pool of WebApplication is applied correctly.
+    * Fixed: The changes of the application pool property of a WebApplication is applied correctly.
 	
 ### 1.11.0.0
 

--- a/Tests/Unit/MSFT_xWebApplication.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebApplication.Tests.ps1
@@ -498,21 +498,21 @@ try
 
                 $script:mockGetWebApplicationCalled = 0
                 $mockWebApplication = {
-                            $script:mockGetWebApplicationCalled++                                
-                            if($script:mockGetWebApplicationCalled -eq 1)
-                            {
-                                return $null
+                    $script:mockGetWebApplicationCalled++                                
+                    if($script:mockGetWebApplicationCalled -eq 1)
+                    {
+                        return $null
+                    }
+                    else
+                    {
+                        return @{
+                            ApplicationPool = $MockParameters.WebAppPool
+                            PhysicalPath    = $MockParameters.PhysicalPath
+                            ItemXPath       = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.Name)
+                            Count           = 1
                             }
-                            else
-                            {
-                                return @{
-                                            ApplicationPool          = $MockParameters.WebAppPool
-                                            PhysicalPath             = $MockParameters.PhysicalPath
-                                            ItemXPath                = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.Name)
-                                            Count = 1
-                                        }
-                            }
-                        }
+                    }
+                }
                 
                 Mock -CommandName Get-WebApplication -MockWith $mockWebApplication
 


### PR DESCRIPTION
This fix solves the problem that the application pool property of a Web Application was not applied to the desired state configuration. Now it is, so when you change the app pool property of a Web Application it will be configured as it is declared in the desired state configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/167)
<!-- Reviewable:end -->
