### PR TITLE
xWebApplication: Fixed Set-TargetResource not updating WebAppPool and PhysicalPath

### DIFF
--- a/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
+++ b/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
@@ -148,13 +148,13 @@ function Set-TargetResource
                 $webApplication = Get-WebApplication -Site $Website -Name $Name
             }
 
-            #Update Physical Path if required
+            # Update Physical Path if required
             if (($PSBoundParameters.ContainsKey('PhysicalPath') -and `
                 $webApplication.physicalPath -ne $PhysicalPath))
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetPhysicalPath -f $Name)
                 Set-WebConfigurationProperty `
-                    -Filter "$($webApplication.ItemXPath)/virtualDirectory[@path='/']" `
+                    -Filter $webApplication.ItemXPath `
                     -Name physicalPath `
                     -Value $PhysicalPath
             }
@@ -165,7 +165,7 @@ function Set-TargetResource
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetWebAppPool -f $Name)
                 Set-WebConfigurationProperty `
-                    -Filter "$($webApplication.ItemXPath)/virtualDirectory[@path='/']" `
+                    -Filter $webApplication.ItemXPath `
                     -Name applicationPool `
                     -Value $WebAppPool
             }

--- a/Tests/Unit/MSFT_xWebApplication.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebApplication.Tests.ps1
@@ -292,7 +292,6 @@ try
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled 
                         Count = 1
                     }
-  
                 }
 
                 It 'should return False' {

--- a/Tests/Unit/MSFT_xWebApplication.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebApplication.Tests.ps1
@@ -77,7 +77,8 @@ try
                 Website                  = 'MockSite'
                 Name                     = 'MockApp'
                 WebAppPool               = 'MockPool'
-                PhysicalPath             = 'C:\MockSite\MockApp'          
+                PhysicalPath             = 'C:\MockSite\MockApp'
+                ItemXPath                = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f 'MockSite', 'MockApp')
             }
             
             Mock -CommandName Get-WebConfiguration -MockWith {
@@ -264,14 +265,12 @@ try
                         ApplicationType          = $MockParameters.ApplicationType
                         Count                    = 1
                     }
- 
                 }
-
+                
                 It 'should return False' {
                     $Result = Test-TargetResource -Ensure 'Present' @MockParameters
                     $Result | Should Be $False
                 }
- 
             }
 
             Context 'Web Application exists but has a different PhysicalPath' {
@@ -513,9 +512,9 @@ try
                         return @{
                             ApplicationPool = $MockParameters.WebAppPool
                             PhysicalPath    = $MockParameters.PhysicalPath
-                            ItemXPath       = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.Name)
+                            ItemXPath       = $MockParameters.ItemXPath
                             Count           = 1
-                            }
+                        }
                     }
                 }
                 
@@ -578,7 +577,7 @@ try
                     return @{
                         ApplicationPool          = 'MockPoolOther'
                         PhysicalPath             = $MockParameters.PhysicalPath
-                        ItemXPath                = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.Name)
+                        ItemXPath                = $MockParameters.ItemXPath
                         PreloadEnabled           = $MockParameters.PreloadEnabled
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled
                         ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider
@@ -618,7 +617,12 @@ try
                     $Result = Set-TargetResource -Ensure 'Present' @MockParameters
 
                     Assert-MockCalled -CommandName Get-WebApplication -Exactly 1
-                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1 `
+                                      -ParameterFilter { `
+                                        ($Filter -eq $MockParameters.ItemXPath) -And `
+                                        ($Name   -eq 'applicationPool') -And `
+                                        ($Value  -eq $MockParameters.WebAppPool) `
+                                      }
                 }
 
             }
@@ -629,7 +633,7 @@ try
                     return @{
                         ApplicationPool          = $MockParameters.WebAppPool
                         PhysicalPath             = 'C:\MockSite\MockAppOther'
-                        ItemXPath                = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.Name)
+                        ItemXPath                = $MockParameters.ItemXPath
                         PreloadEnabled           = $MockParameters.PreloadEnabled
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled
                         ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider
@@ -670,9 +674,13 @@ try
                     $Result = Set-TargetResource -Ensure 'Present' @MockParameters
 
                     Assert-MockCalled -CommandName Get-WebApplication -Exactly 1
-                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1 `
+                                      -ParameterFilter { `
+                                        ($Filter -eq $MockParameters.ItemXPath) -And `
+                                        ($Name   -eq 'physicalPath') -And `
+                                        ($Value  -eq $MockParameters.PhysicalPath) `
+                                      }
                 }
- 
             }
 
             Context 'Web Application exists but has different AuthenticationInfo' {
@@ -680,8 +688,8 @@ try
                 Mock -CommandName Get-WebApplication -MockWith {
                         return @{
                             ApplicationPool          = $MockParameters.WebAppPool
-                            PhysicalPath             =  $MockParameters.PhysicalPath
-                            ItemXPath                = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.Name)
+                            PhysicalPath             = $MockParameters.PhysicalPath
+                            ItemXPath                = $MockParameters.ItemXPath
                             PreloadEnabled           = $MockParameters.PreloadEnabled
                             ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled
                             ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider
@@ -730,8 +738,8 @@ try
                 Mock -CommandName Get-WebApplication -MockWith {
                     return @{
                         ApplicationPool          = $MockParameters.WebAppPool
-                        PhysicalPath             =  $MockParameters.PhysicalPath
-                        ItemXPath                = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.Name)
+                        PhysicalPath             = $MockParameters.PhysicalPath
+                        ItemXPath                = $MockParameters.ItemXPath
                         PreloadEnabled           = 'false'
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled
                         ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider
@@ -770,8 +778,8 @@ try
                 Mock -CommandName Get-WebApplication -MockWith {
                     return @{
                         ApplicationPool          = $MockParameters.WebAppPool
-                        PhysicalPath             =  $MockParameters.PhysicalPath
-                        ItemXPath                = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.Name)
+                        PhysicalPath             = $MockParameters.PhysicalPath
+                        ItemXPath                = $MockParameters.ItemXPath
                         PreloadEnabled           = 'false'
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled
                         ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider
@@ -809,8 +817,8 @@ try
                 Mock -CommandName Get-WebApplication -MockWith {
                     return @{
                         ApplicationPool          = $MockParameters.WebAppPool
-                        PhysicalPath             =  $MockParameters.PhysicalPath
-                        ItemXPath                = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.Name)
+                        PhysicalPath             = $MockParameters.PhysicalPath
+                        ItemXPath                = $MockParameters.ItemXPath
                         PreloadEnabled           = $MockParameters.PreloadEnabled
                         ServiceAutoStartEnabled  = 'false'
                         ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider    
@@ -860,8 +868,8 @@ try
                Mock -CommandName Get-WebApplication -MockWith {
                     return @{
                         ApplicationPool          = $MockParameters.WebAppPool
-                        PhysicalPath             =  $MockParameters.PhysicalPath
-                        ItemXPath                = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.Name)
+                        PhysicalPath             = $MockParameters.PhysicalPath
+                        ItemXPath                = $MockParameters.ItemXPath
                         PreloadEnabled           = $MockParameters.PreloadEnabled
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled 
                         ServiceAutoStartProvider = 'OtherServiceAutoStartProvider'

--- a/Tests/Unit/MSFT_xWebApplication.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebApplication.Tests.ps1
@@ -617,11 +617,11 @@ try
                     $Result = Set-TargetResource -Ensure 'Present' @MockParameters
 
                     Assert-MockCalled -CommandName Get-WebApplication -Exactly 1
-                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1 `
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Scope It -Exactly 1 `
                                       -ParameterFilter { `
-                                        ($Filter -eq $MockItemXPath) -And `
+                                        ($Filter -eq "/system.applicationHost/sites/site[@name='MockSite']/application[@path='/MockPool']") -And `
                                         ($Name   -eq 'applicationPool') -And `
-                                        ($Value  -eq $MockParameters.WebAppPool) `
+                                        ($Value  -eq 'MockPool') `
                                       }
                 }
 
@@ -676,9 +676,9 @@ try
                     Assert-MockCalled -CommandName Get-WebApplication -Exactly 1
                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1 `
                                       -ParameterFilter { `
-                                        ($Filter -eq $MockItemXPath) -And `
+                                        ($Filter -eq "/system.applicationHost/sites/site[@name='MockSite']/application[@path='/MockPool']") -And `
                                         ($Name   -eq 'physicalPath') -And `
-                                        ($Value  -eq $MockParameters.PhysicalPath) `
+                                        ($Value  -eq 'C:\MockSite\MockApp') `
                                       }
                 }
             }

--- a/Tests/Unit/MSFT_xWebApplication.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebApplication.Tests.ps1
@@ -39,8 +39,9 @@ try
             ServiceAutoStartEnabled  = $True
             ApplicationType          = 'MockApplicationType'
             AuthenticationInfo       = $MockAuthenticationInfo
-           
         }
+        
+        $MockItemXPath = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.WebAppPool)
 
         $GetWebConfigurationOutput = @(
                 @{
@@ -79,8 +80,6 @@ try
                 WebAppPool               = 'MockPool'
                 PhysicalPath             = 'C:\MockSite\MockApp'
             }
-            
-            $MockItemXPath = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.WebAppPool)
             
             Mock -CommandName Get-WebConfiguration -MockWith {
                     return $GetWebConfigurationOutput

--- a/Tests/Unit/MSFT_xWebApplication.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebApplication.Tests.ps1
@@ -78,8 +78,9 @@ try
                 Name                     = 'MockApp'
                 WebAppPool               = 'MockPool'
                 PhysicalPath             = 'C:\MockSite\MockApp'
-                ItemXPath                = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f 'MockSite', 'MockApp')
             }
+            
+            $MockItemXPath = ("/system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']" -f $MockParameters.Website, $MockParameters.WebAppPool)
             
             Mock -CommandName Get-WebConfiguration -MockWith {
                     return $GetWebConfigurationOutput
@@ -511,7 +512,7 @@ try
                         return @{
                             ApplicationPool = $MockParameters.WebAppPool
                             PhysicalPath    = $MockParameters.PhysicalPath
-                            ItemXPath       = $MockParameters.ItemXPath
+                            ItemXPath       = $MockItemXPath
                             Count           = 1
                         }
                     }
@@ -576,7 +577,7 @@ try
                     return @{
                         ApplicationPool          = 'MockPoolOther'
                         PhysicalPath             = $MockParameters.PhysicalPath
-                        ItemXPath                = $MockParameters.ItemXPath
+                        ItemXPath                = $MockItemXPath
                         PreloadEnabled           = $MockParameters.PreloadEnabled
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled
                         ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider
@@ -618,7 +619,7 @@ try
                     Assert-MockCalled -CommandName Get-WebApplication -Exactly 1
                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1 `
                                       -ParameterFilter { `
-                                        ($Filter -eq $MockParameters.ItemXPath) -And `
+                                        ($Filter -eq $MockItemXPath) -And `
                                         ($Name   -eq 'applicationPool') -And `
                                         ($Value  -eq $MockParameters.WebAppPool) `
                                       }
@@ -632,7 +633,7 @@ try
                     return @{
                         ApplicationPool          = $MockParameters.WebAppPool
                         PhysicalPath             = 'C:\MockSite\MockAppOther'
-                        ItemXPath                = $MockParameters.ItemXPath
+                        ItemXPath                = $MockItemXPath
                         PreloadEnabled           = $MockParameters.PreloadEnabled
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled
                         ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider
@@ -675,7 +676,7 @@ try
                     Assert-MockCalled -CommandName Get-WebApplication -Exactly 1
                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1 `
                                       -ParameterFilter { `
-                                        ($Filter -eq $MockParameters.ItemXPath) -And `
+                                        ($Filter -eq $MockItemXPath) -And `
                                         ($Name   -eq 'physicalPath') -And `
                                         ($Value  -eq $MockParameters.PhysicalPath) `
                                       }
@@ -688,7 +689,7 @@ try
                         return @{
                             ApplicationPool          = $MockParameters.WebAppPool
                             PhysicalPath             = $MockParameters.PhysicalPath
-                            ItemXPath                = $MockParameters.ItemXPath
+                            ItemXPath                = $MockItemXPath
                             PreloadEnabled           = $MockParameters.PreloadEnabled
                             ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled
                             ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider
@@ -738,7 +739,7 @@ try
                     return @{
                         ApplicationPool          = $MockParameters.WebAppPool
                         PhysicalPath             = $MockParameters.PhysicalPath
-                        ItemXPath                = $MockParameters.ItemXPath
+                        ItemXPath                = $MockItemXPath
                         PreloadEnabled           = 'false'
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled
                         ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider
@@ -778,7 +779,7 @@ try
                     return @{
                         ApplicationPool          = $MockParameters.WebAppPool
                         PhysicalPath             = $MockParameters.PhysicalPath
-                        ItemXPath                = $MockParameters.ItemXPath
+                        ItemXPath                = $MockItemXPath
                         PreloadEnabled           = 'false'
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled
                         ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider
@@ -817,7 +818,7 @@ try
                     return @{
                         ApplicationPool          = $MockParameters.WebAppPool
                         PhysicalPath             = $MockParameters.PhysicalPath
-                        ItemXPath                = $MockParameters.ItemXPath
+                        ItemXPath                = $MockItemXPath
                         PreloadEnabled           = $MockParameters.PreloadEnabled
                         ServiceAutoStartEnabled  = 'false'
                         ServiceAutoStartProvider = $MockParameters.ServiceAutoStartProvider    
@@ -868,7 +869,7 @@ try
                     return @{
                         ApplicationPool          = $MockParameters.WebAppPool
                         PhysicalPath             = $MockParameters.PhysicalPath
-                        ItemXPath                = $MockParameters.ItemXPath
+                        ItemXPath                = $MockItemXPath
                         PreloadEnabled           = $MockParameters.PreloadEnabled
                         ServiceAutoStartEnabled  = $MockParameters.ServiceAutoStartEnabled 
                         ServiceAutoStartProvider = 'OtherServiceAutoStartProvider'


### PR DESCRIPTION
Fixed calls to Set-WebConfigurationProperty in Set-TargetResource when updating PhysicalPath and WebAppPool