### PR TITLE
switching xIisFeatureDelegation to download common tests with git 

### DIFF
--- a/Tests/Unit/MSFT_xIISFeatureDelegation.tests.ps1
+++ b/Tests/Unit/MSFT_xIISFeatureDelegation.tests.ps1
@@ -3,61 +3,14 @@ $script:DSCModuleName = 'xWebAdministration'
 $script:DSCResourceName = 'MSFT_xIISFeatureDelegation'
 
 #region HEADER
-
 $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-$repoSource = (Get-Module -Name $script:DSCModuleName -ListAvailable)
-
-# If module was obtained from the gallery install test folder from the gallery instead of cloning from git
-if (($null -ne $repoSource) -and ($repoSource[0].RepositorySourceLocation.Host -eq 'www.powershellgallery.com'))
+ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    if ( -not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\DscResourceTestHelper')) )
-    {
-        $choice = 'y'
-
-        # If user wants to skip prompt - set this environment variale equal to 'true'
-        if ($env:getDscTestHelper -ne $true)
-        {
-            $choice = read-host 'In order to run this test you need to install a helper module, continue with installation? (Y/N)'
-        }
-
-        if ($choice -eq 'y')
-        {
-            # Install test folders from gallery
-            Save-Module -Name 'DscResourceTestHelper' -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests')
-        }
-
-        else 
-        {
-            Write-Error 'Unable to run tests without the required helper module - Exiting test'
-            return
-        }
-        
-    }
-
-    $testModuleVer = Get-ChildItem -Path (Join-Path -Path $script:moduleRoot -ChildPath '\Tests\DscResourceTestHelper')
-    Import-Module (Join-Path -Path $script:moduleRoot -ChildPath "Tests\DscResourceTestHelper\$testModuleVer\TestHelper.psm1") -Force
-} 
-# Otherwise module was cloned from github
-else
-{
-    # Get common tests and test helpers from gitHub rather than installing them from the gallery
-    # This ensures that developers always have access to the most recent DscResource.Tests folder 
-    $testHelperPath = (Join-Path -Path $script:moduleRoot -ChildPath '\Tests\DscResource.Tests\DscResourceTestHelper\TestHelper.psm1')
-    if (-not (Test-Path -Path $testHelperPath))
-    {
-        # Clone test folders from gitHub
-        $dscResourceTestsPath = Join-Path -Path $script:moduleRoot -ChildPath '\Tests\DscResource.Tests'
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',$dscResourceTestsPath)
-        
-        # TODO get rid of this section once we update all other resources and merge the gitDependency branch with the main branch on DscResource.Tests
-        Push-Location
-        Set-Location $dscResourceTestsPath
-        & git checkout gitDependency
-        Pop-Location
-    }
-
-    Import-Module $testHelperPath -Force
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\MockWebAdministrationWindowsFeature.psm1')
 


### PR DESCRIPTION
Until we make an official decision on how to handle getting rid of the git dependency, all of the resources should be downloading the common tests the same way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/239)
<!-- Reviewable:end -->
