### PR TITLE
Corrected name of AuthenticationInfo parameter in Readme.md - Fixes #242

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Currently, only FastCgiModule is supported.
 * **ServiceAutoStartEnabled**: When set to `$true` this will enable Autostart on a Website
 * **ServiceAutoStartProvider**: Adds a AutostartProvider
 * **ApplicationType**: Adds a AutostartProvider ApplicationType
-* **AuthenticationInformation**: Website's authentication information in the form of an array of embedded instances of the **MSFT_xWebAuthenticationInformation** CIM class. **MSFT_xWebAuthenticationInformation** take the following properties:
+* **AuthenticationInfo**: Website's authentication information in the form of an array of embedded instances of the **MSFT_xWebAuthenticationInformation** CIM class. **MSFT_xWebAuthenticationInformation** take the following properties:
     * **Anonymous**: The acceptable values for this property are: `$true`, `$false`
     * **Basic**: The acceptable values for this property are: `$true`, `$false`
     * **Digest**: The acceptable values for this property are: `$true`, `$false`
@@ -172,7 +172,7 @@ Currently, only FastCgiModule is supported.
 * **ServiceAutoStartEnabled**: When set to `$true` this will enable Autostart on a Website
 * **ServiceAutoStartProvider**: Adds a AutostartProvider
 * **ApplicationType**: Adds a AutostartProvider ApplicationType
-* **AuthenticationInformation**: Web Application's authentication information in the form of an array of embedded instances of the **MSFT_xWebApplicationAuthenticationInformation** CIM class. **MSFT_xWebApplicationAuthenticationInformation** take the following properties:
+* **AuthenticationInfo**: Web Application's authentication information in the form of an array of embedded instances of the **MSFT_xWebApplicationAuthenticationInformation** CIM class. **MSFT_xWebApplicationAuthenticationInformation** take the following properties:
     * **Anonymous**: The acceptable values for this property are: `$true`, `$false`
     * **Basic**: The acceptable values for this property are: `$true`, `$false`
     * **Digest**: The acceptable values for this property are: `$true`, `$false`
@@ -216,9 +216,11 @@ Currently, only FastCgiModule is supported.
 
 ### Unreleased
 
+* Corrected name of AuthenticationInfo parameter in Readme.md.
+
 ### 1.14.0.0
 
-* xWebApplication: 
+* xWebApplication:
 	* Fixed bug when setting PhysicalPath and WebAppPool
 	* Changes to the application pool property are now applied correctly
 
@@ -257,13 +259,13 @@ Currently, only FastCgiModule is supported.
 
 * **xWebApplication** updates:
     * Added integration tests and added option to SslFlags
-    * Fixed: 
-         * Formatted resources to DSC StyleGuideLines 
+    * Fixed:
+         * Formatted resources to DSC StyleGuideLines
          * Logging statements
          * Incorrect Get-TargetResource param block
          * Test-SslFlags validation
          * Unit test mocking of Test-SslFlags
-	
+
 ### 1.11.0.0
 
 * **xWebAppPool** updates:


### PR DESCRIPTION
AuthenticationInfo parameters in Readme.md were listed as AuthenticationInformation. This PR corrects this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/243)
<!-- Reviewable:end -->
