### PR TITLE
No examples for xWebApplication (Fixes #190)

### DIFF
--- a/Examples/Sample_xWebApplication_NewWebApplication.ps1
+++ b/Examples/Sample_xWebApplication_NewWebApplication.ps1
@@ -18,7 +18,8 @@ Configuration Sample_xWebApplication_NewWebApplication
     )
 
     # Import the module that defines custom resources
-    Import-DscResource -Module xWebAdministration, PSDesiredStateConfiguration
+    Import-DscResource -Module PSDesiredStateConfiguration
+    Import-DscResource -Module xWebAdministration
 
     Node $NodeName
     {

--- a/Examples/Sample_xWebApplication_NewWebApplication.ps1
+++ b/Examples/Sample_xWebApplication_NewWebApplication.ps1
@@ -1,0 +1,89 @@
+<#
+.SYNOPSIS
+    Create a new web application on the Default Web Site
+.DESCRIPTION
+    This example shows how to use the xWebApplication DSC resource to create a new web application.
+#>
+Configuration Sample_xWebApplication_NewWebApplication
+{
+    param
+    (
+        # Target nodes to apply the configuration
+        [String[]] $NodeName = 'localhost',
+
+        # Destination path for Website content
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String] $DestinationPath
+    )
+
+    # Import the module that defines custom resources
+    Import-DscResource -Module xWebAdministration, PSDesiredStateConfiguration
+
+    Node $NodeName
+    {
+        # Install the IIS role
+        WindowsFeature IIS
+        {
+            Ensure                  = 'Present'
+            Name                    = 'Web-Server'
+        }
+
+        # Install the ASP .NET 4.5 role
+        WindowsFeature AspNet45
+        {
+            Ensure                  = 'Present'
+            Name                    = 'Web-Asp-Net45'
+        }
+
+        # Start the Default Web Site
+        xWebsite DefaultSite 
+        {
+            Ensure                  = 'Present'
+            Name                    = 'Default Web Site'
+            State                   = 'Started'
+            PhysicalPath            = 'C:\inetpub\wwwroot'
+            DependsOn               = '[WindowsFeature]IIS'
+        }
+
+        # Create a new application pool for the application
+        xWebAppPool SampleAppPool
+        {
+            Ensure                  = 'Present'
+            Name                    = 'SampleAppPool'
+        }
+
+        # Clone the wwwroot folder to the destination
+        File WebContent
+        {
+            Ensure                  = 'Present'
+            SourcePath              = 'C:\inetpub\wwwroot'
+            DestinationPath         = $DestinationPath
+            Recurse                 = $true
+            Type                    = 'Directory'
+            DependsOn               = '[WindowsFeature]IIS'
+        }
+
+        # Create a new web application with Windows Authentication
+        xWebApplication SampleApplication 
+        {
+            Ensure                  = 'Present'
+            Name                    = 'SampleApplication'
+            WebAppPool              = 'SampleAppPool'
+            Website                 = 'Default Web Site'
+            PreloadEnabled          = $true
+            ServiceAutoStartEnabled = $true
+            AuthenticationInfo      = MSFT_xWebApplicationAuthenticationInformation
+            {
+                Anonymous   = $false
+                Basic       = $false
+                Digest      = $false
+                Windows     = $true
+            }
+            SslFlags                = ''
+            PhysicalPath            = $DestinationPath
+            DependsOn               = '[xWebsite]DefaultSite','[xWebAppPool]SampleAppPool'
+        }
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Currently, only FastCgiModule is supported.
 ### Unreleased
 
 * Corrected name of AuthenticationInfo parameter in Readme.md.
+* Added sample for **xWebApplication** for adding new web application.
 
 ### 1.14.0.0
 


### PR DESCRIPTION
Added a sample for adding a sample web application on the Default Web Site. It's configured to use Windows Authentication and will use a copy of C:\inetpub\wwwroot as content. As a fix for #190.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/246)
<!-- Reviewable:end -->
