### PR TITLE
Changed xWebsite LogPath to directory attribute. Fixes #256

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -62,7 +62,7 @@ data LocalizedData
         VerboseTestTargetFalseAuthenticationInfo = AuthenticationInfo for website "{0}" is not in the desired state.
         VerboseTestTargetFalseIISAutoStartProvider = AutoStartProvider for IIS is not in the desired state
         VerboseTestTargetFalseWebsiteAutoStartProvider = AutoStartProvider for website "{0}" is not in the desired state
-        VerboseTestTargetFalseLogPath = LogPath does match desired state on Website "{0}".
+        VerboseTestTargetFalseLogPath = LogPath does not match desired state on Website "{0}".
         VerboseTestTargetFalseLogFlags = LogFlags does not match desired state on Website "{0}".
         VerboseTestTargetFalseLogPeriod = LogPeriod does not match desired state on Website "{0}".
         VerboseTestTargetFalseLogTruncateSize = LogTruncateSize does not match desired state on Website "{0}".
@@ -445,9 +445,8 @@ function Set-TargetResource
 
             # Update LogPath if required
             if ($PSBoundParameters.ContainsKey('LogPath') -and `
-                ($LogPath -ne $website.logfile.LogPath))
+                ($LogPath -ne $website.logfile.directory))
             {
-
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogPath `
                                         -f $Name)
                 Set-ItemProperty -Path "IIS:\Sites\$Name" `
@@ -683,7 +682,7 @@ function Set-TargetResource
 
             # Update LogPath if required
             if ($PSBoundParameters.ContainsKey('LogPath') -and `
-                ($LogPath -ne $website.logfile.LogPath))
+                ($LogPath -ne $website.logfile.directory))
             {
 
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogPath `
@@ -995,7 +994,7 @@ function Test-TargetResource
 
         # Check LogPath
         if ($PSBoundParameters.ContainsKey('LogPath') -and `
-            ($LogPath -ne $website.logfile.LogPath))
+            ($LogPath -ne $website.logfile.directory))
         {
             Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalseLogPath `
                                     -f $Name)

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ Currently, only FastCgiModule is supported.
 
 ### Unreleased
 
+* Log directory configuration on **xWebsite** used the logPath attribute instead of the directory attribute. Bugfix for #256.
+
 ### 1.15.0.0
 
 * Corrected name of AuthenticationInfo parameter in Readme.md.

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -494,31 +494,31 @@ try
             }
 
             Context 'Check AutoStartProvider is different' {
-                Mock -CommandName Get-Website -MockWith {return $MockWebsite}
+                Mock -CommandName Get-Website -MockWith { return $MockWebsite }
 
-                $Result = Test-TargetResource -Ensure $MockParameters.Ensure `
+                $result = Test-TargetResource -Ensure $MockParameters.Ensure `
                             -Name $MockParameters.Name `
                             -PhysicalPath $MockParameters.PhysicalPath `
                             -ServiceAutoStartProvider 'MockAutoStartProviderDifferent' `
                             -ApplicationType 'MockApplicationTypeDifferent' `
                             -Verbose:$VerbosePreference
 
-                It 'should return False' {
-                    $Result | Should Be $false
+                It 'Should return False' {
+                    $result | Should Be $false
                 }
             }
 
             Context 'Check LogPath is equal' {
                 $MockLogOutput.directory = $MockParameters.LogPath
 
-                Mock -CommandName Test-Path -MockWith {Return $true}
+                Mock -CommandName Test-Path -MockWith { return $true }
 
-                Mock -CommandName Get-Website -MockWith {return $MockWebsite}
+                Mock -CommandName Get-Website -MockWith { return $MockWebsite }
 
                 Mock -CommandName Get-WebConfigurationProperty `
-                    -MockWith {return $MockLogOutput.logExtFileFlags }
+                    -MockWith { return $MockLogOutput.logExtFileFlags }
 
-                $Result = Test-TargetResource -Ensure $MockParameters.Ensure `
+                $result = Test-TargetResource -Ensure $MockParameters.Ensure `
                                 -Name $MockParameters.Name `
                                 -PhysicalPath $MockParameters.PhysicalPath `
                                 -LogPath $MockParameters.LogPath `
@@ -532,14 +532,14 @@ try
             Context 'Check LogPath is different' {
                 $MockLogOutput.directory = $MockParameters.LogPath
 
-                Mock -CommandName Test-Path -MockWith {Return $true}
+                Mock -CommandName Test-Path -MockWith { return $true }
 
-                Mock -CommandName Get-Website -MockWith {return $MockWebsite}
+                Mock -CommandName Get-Website -MockWith { return $MockWebsite }
 
                 Mock -CommandName Get-WebConfigurationProperty `
-                    -MockWith {return $MockLogOutput.logExtFileFlags }
+                    -MockWith { return $MockLogOutput.logExtFileFlags }
 
-                $Result = Test-TargetResource -Ensure $MockParameters.Ensure `
+                $result = Test-TargetResource -Ensure $MockParameters.Ensure `
                                 -Name $MockParameters.Name `
                                 -PhysicalPath $MockParameters.PhysicalPath `
                                 -LogPath 'C:\MockLogPath2' `
@@ -560,14 +560,14 @@ try
                     localTimeRollover = $MockParameters.LoglocalTimeRollover
                 }
 
-                Mock -CommandName Test-Path -MockWith {Return $true}
+                Mock -CommandName Test-Path -MockWith { return $true }
 
-                Mock -CommandName Get-Website -MockWith {return $MockWebsite}
+                Mock -CommandName Get-Website -MockWith { return $MockWebsite }
 
                 Mock -CommandName Get-WebConfigurationProperty `
-                    -MockWith {return $MockLogOutput.logExtFileFlags }
+                    -MockWith { return $MockLogOutput.logExtFileFlags }
 
-                $Result = Test-TargetResource -Ensure $MockParameters.Ensure `
+                $result = Test-TargetResource -Ensure $MockParameters.Ensure `
                     -Name $MockParameters.Name `
                     -PhysicalPath $MockParameters.PhysicalPath `
                     -LogFlags 'Date','Time','ClientIP','UserName','ServerIP' `
@@ -1030,7 +1030,7 @@ try
                     }
                 }
 
-                Mock -CommandName Get-Website -MockWith {return $MockWebsite}
+                Mock -CommandName Get-Website -MockWith { return $MockWebsite }
 
                 Mock -CommandName Get-Command -MockWith {
                     return @{
@@ -1066,9 +1066,9 @@ try
                 Mock -CommandName Test-AuthenticationEnabled { return $false } `
                     -ParameterFilter { ($Type -eq 'Windows') }
 
-                $Result = Set-TargetResource @MockParameters
+                $result = Set-TargetResource @MockParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Set-ItemProperty -Exactly 8
@@ -1100,7 +1100,7 @@ try
                     }
                 }
 
-                Mock -CommandName Get-Website -MockWith {return $MockWebsite}
+                Mock -CommandName Get-Website -MockWith { return $MockWebsite }
 
                 Mock -CommandName Get-Command -MockWith {
                     return @{
@@ -1136,9 +1136,9 @@ try
                 Mock -CommandName Test-AuthenticationEnabled { return $false } `
                     -ParameterFilter { ($Type -eq 'Windows') }
 
-                $Result = Set-TargetResource @MockParameters
+                $result = Set-TargetResource @MockParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Set-ItemProperty -Exactly 9


### PR DESCRIPTION
- Changed VerboseTestTargetFalseLogPath: The error message did not contain 'not'
- Changed instances of `$website.logfile.LogPath` to `$website.logfile.directory`
- Added extra unit tests for xWebsite.

Fixes #256

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/257)
<!-- Reviewable:end -->
