### PR TITLE
Replacing $TestEnvironment.WorkingFolder calls with $TestDrive

### DIFF
--- a/Tests/Integration/MSFT_XIISLogging.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_XIISLogging.Integration.Tests.ps1
@@ -32,8 +32,8 @@ try {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Rollover -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Rollover -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -44,8 +44,8 @@ try {
 
         It 'Changing Loggging Rollover Settings ' -test {
 
-            Invoke-Expression -Command "$($script:DSCResourceName)_Rollover -OutputPath `$TestEnvironment.WorkingFolder"
-            Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+            Invoke-Expression -Command "$($script:DSCResourceName)_Rollover -OutputPath `$TestDrive"
+            Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             
             $currentLogSettings = Get-WebConfiguration -filter '/system.applicationHost/sites/siteDefaults/Logfile'
                
@@ -62,8 +62,8 @@ try {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Truncate -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Truncate -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -73,8 +73,8 @@ try {
         #endregion
         It 'Changing Loggging Truncate Settings ' -test {
 
-            Invoke-Expression -Command "$($script:DSCResourceName)_Truncate -OutputPath `$TestEnvironment.WorkingFolder"
-            Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+            Invoke-Expression -Command "$($script:DSCResourceName)_Truncate -OutputPath `$TestDrive"
+            Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             
             $currentLogSettings = Get-WebConfiguration -filter '/system.applicationHost/sites/siteDefaults/Logfile'
                

--- a/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
@@ -39,8 +39,8 @@ try
             {
                 It 'Allow Feature Delegation'{
                     {
-                        &($script:DSCResourceName + '_AllowDelegation') -OutputPath $TestEnvironment.WorkingFolder
-                        Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                        &($script:DSCResourceName + '_AllowDelegation') -OutputPath $TestDrive
+                        Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
                     } | Should not throw
 
                     (Get-WebConfiguration /system.webserver/security/authentication/anonymousAuthentication iis:\).OverrideModeEffective  | Should be 'Allow'
@@ -57,8 +57,8 @@ try
         #         # well it doesn't test the Set Method, but does test the Test method
         #         # What if the default document module is not installed?
 
-        #         Invoke-Expression -Command "$($script:DSCResourceName)_DenyDelegation -OutputPath `$TestEnvironment.WorkingFolder"
-        #         Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+        #         Invoke-Expression -Command "$($script:DSCResourceName)_DenyDelegation -OutputPath `$TestDrive"
+        #         Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
 
         #         # Now lets try to add a new default document on site level, this should fail
         #         # get the first site, it doesn't matter which one, it should fail.
@@ -86,8 +86,8 @@ try
         #    # well it doesn't test the Set Method, but does test the Test method
         #    # What if the default document module is not installed?
 
-        #    Invoke-Expression -Command "$($script:DSCResourceName)_DenyDelegation -OutputPath `$TestEnvironment.WorkingFolder"
-        #    Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+        #    Invoke-Expression -Command "$($script:DSCResourceName)_DenyDelegation -OutputPath `$TestDrive"
+        #    Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
 
         #    # Now lets try to add a new default document on site level, this should fail
         #    # get the first site, it doesn't matter which one, it should fail.

--- a/Tests/Integration/MSFT_xIISHandler.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIISHandler.Integration.Tests.ps1
@@ -32,8 +32,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_RemoveHandler -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_RemoveHandler -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -49,8 +49,8 @@ try
             {
                 # TRACEVerbHandler is usually there, remove it
 
-                Invoke-Expression -Command "$($script:DSCResourceName)_AddHandler -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_AddHandler -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             }  | should not throw
 
             [string]$filter = "system.webServer/handlers/Add[@Name='WebDAV']"
@@ -60,8 +60,8 @@ try
         It 'StaticFile handler' {
             # StaticFile is usually there, have it present shouldn't change anything.
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_StaticFileHandler -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_StaticFileHandler -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             }  | should not throw
 
             [string]$filter = "system.webServer/handlers/Add[@Name='StaticFile']"

--- a/Tests/Integration/MSFT_xIISMimeTypeMapping.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIISMimeTypeMapping.Integration.Tests.ps1
@@ -32,8 +32,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Config -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -49,8 +49,8 @@ try
             $env:PesterMimeType2 = $node.mimeType
 
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_AddMimeType -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_AddMimeType -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
 
             [string] $filter = "system.webServer/staticContent/mimeMap[@fileExtension='" + $env:PesterFileExtension2 + "' and @mimeType='" + "$env:PesterMimeType2" + "']"
@@ -65,8 +65,8 @@ try
             $env:PesterMimeType = $node.mimeType
 
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_RemoveMimeType -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_RemoveMimeType -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
 
             [string] $filter = "system.webServer/staticContent/mimeMap[@fileExtension='" + $env:PesterFileExtension + "' and @mimeType='" + "$env:PesterMimeType" + "']"
@@ -75,8 +75,8 @@ try
 
         It 'Removing a non existing MimeType' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_RemoveDummyMime -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_RemoveDummyMime -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
     }

--- a/Tests/Integration/MSFT_xSSLSettings.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSSLSettings.Integration.Tests.ps1
@@ -70,8 +70,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Present -ConfigurationData `$DSCConfig -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Present -ConfigurationData `$DSCConfig -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -82,7 +82,7 @@ try
 
         It 'Should add SSLBindings to a Website' -test {
             
-            Invoke-Expression -Command "$($script:DSCResourceName)_Present -ConfigurationData `$DSCConfg  -OutputPath `$TestEnvironment.WorkingFolder"
+            Invoke-Expression -Command "$($script:DSCResourceName)_Present -ConfigurationData `$DSCConfg  -OutputPath `$TestDrive"
            
             # Test SslFlags
             Get-SslFlags -Website $DSCConfig.AllNodes.Website | Should Be $DSCConfig.AllNodes.Bindings
@@ -95,8 +95,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$DSCConfig -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$DSCConfig -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -107,7 +107,7 @@ try
         
         It 'Should remove SSLBindings from a Website' -test {
             
-            Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$DSCConfg  -OutputPath `$TestEnvironment.WorkingFolder"
+            Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$DSCConfg  -OutputPath `$TestDrive"
 
             # Test SslFlags
             Get-SslFlags -Website $DSCConfig.AllNodes.Website | Should BeNullOrEmpty

--- a/Tests/Integration/MSFT_xWebAppPool.Integration.tests.ps1
+++ b/Tests/Integration/MSFT_xWebAppPool.Integration.tests.ps1
@@ -49,11 +49,11 @@ try
         It 'Should be able to compile and apply without throwing' {
             {
                 Invoke-Expression -Command (
-                    '{0}_Config -OutputPath $TestEnvironment.WorkingFolder -ConfigurationData $ConfigData -ErrorAction Stop' -f
+                    '{0}_Config -OutputPath $TestDrive -ConfigurationData $ConfigData -ErrorAction Stop' -f
                     $script:DSCResourceName
                 )
 
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Force -Wait -Verbose
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Force -Wait -Verbose
             } | Should Not Throw
         }
 

--- a/Tests/Integration/MSFT_xWebAppPoolDefaults.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebAppPoolDefaults.Integration.Tests.ps1
@@ -45,8 +45,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Config -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -72,8 +72,8 @@ try
                     $env:PesterManagedRuntimeVersion =  'v4.0'
                 }
 
-                Invoke-Expression -Command "$($script:DSCResourceName)_ManagedRuntimeVersion -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_ManagedRuntimeVersion -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             }  | should not throw
 
             # get the configured value again
@@ -101,8 +101,8 @@ try
 
             # Compile the MOF File
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_AppPoolIdentityType -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_AppPoolIdentityType -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
 
             $changedValue = (Get-WebConfigurationProperty -PSPath $constPsPath -Filter $constAPDFilter/processModel -Name identityType)
@@ -125,8 +125,8 @@ try
 
             # Compile the MOF File
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_LogFormat -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_LogFormat -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
 
             $changedValue = Get-SiteValue 'logFile' 'logFormat'
@@ -142,8 +142,8 @@ try
             $env:PesterDefaultPool =  'DefaultAppPool'
             # Compile the MOF File
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_DefaultPool -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_DefaultPool -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
 
             $changedValue = Get-SiteValue 'applicationDefaults' 'applicationPool'

--- a/Tests/Integration/MSFT_xWebApplication.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebApplication.Integration.Tests.ps1
@@ -71,8 +71,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Present -ConfigurationData `$DSCConfig -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Present -ConfigurationData `$DSCConfig -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -83,7 +83,7 @@ try
 
         It 'Should create a WebApplication with correct settings' -test {
             
-            Invoke-Expression -Command "$($script:DSCResourceName)_Present -ConfigurationData `$DSCConfg  -OutputPath `$TestEnvironment.WorkingFolder"
+            Invoke-Expression -Command "$($script:DSCResourceName)_Present -ConfigurationData `$DSCConfg  -OutputPath `$TestDrive"
 
             # Build results to test
             $Result = Get-WebApplication -Site $DSCConfig.AllNodes.Website -Name $DSCConfig.AllNodes.WebApplication
@@ -120,8 +120,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$DSCConfig -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$DSCConfig -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -132,7 +132,7 @@ try
         
         It 'Should remove the WebApplication' -test {
             
-            Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$DSCConfg  -OutputPath `$TestEnvironment.WorkingFolder"
+            Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$DSCConfg  -OutputPath `$TestDrive"
 
             # Build results to test
             $Result = Get-WebApplication -Site $DSCConfig.AllNodes.Website -Name $DSCConfig.AllNodes.WebApplication

--- a/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
@@ -58,8 +58,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Present_Started -ConfigurationData `$dscConfig -OutputPath `$TestEnvironment.WorkingFolder -CertificateThumbprint `$selfSignedCert.Thumbprint"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Present_Started -ConfigurationData `$dscConfig -OutputPath `$TestDrive -CertificateThumbprint `$selfSignedCert.Thumbprint"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -70,7 +70,7 @@ try
 
         It 'Should Create a Started Website with correct settings' -test {
             
-            Invoke-Expression -Command "$($script:DSCResourceName)_Present_Started -ConfigurationData `$dscConfg  -OutputPath `$TestEnvironment.WorkingFolder -CertificateThumbprint `$selfSignedCert.Thumbprint"
+            Invoke-Expression -Command "$($script:DSCResourceName)_Present_Started -ConfigurationData `$dscConfg  -OutputPath `$TestDrive -CertificateThumbprint `$selfSignedCert.Thumbprint"
 
             # Build results to test
             $result = Get-Website -Name $dscConfig.AllNodes.Website
@@ -126,8 +126,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Present_Stopped -ConfigurationData `$dscConfig -OutputPath `$TestEnvironment.WorkingFolder -CertificateThumbprint `$selfSignedCert.Thumbprint"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Present_Stopped -ConfigurationData `$dscConfig -OutputPath `$TestDrive -CertificateThumbprint `$selfSignedCert.Thumbprint"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -138,7 +138,7 @@ try
         
         It 'Should Create a Stopped Website with correct settings' -test {
             
-            Invoke-Expression -Command "$($script:DSCResourceName)_Present_Stopped -ConfigurationData `$dscConfg  -OutputPath `$TestEnvironment.WorkingFolder -CertificateThumbprint `$selfSignedCert.Thumbprint"
+            Invoke-Expression -Command "$($script:DSCResourceName)_Present_Stopped -ConfigurationData `$dscConfg  -OutputPath `$TestDrive -CertificateThumbprint `$selfSignedCert.Thumbprint"
 
             # Build results to test
             $result = Get-Website -Name $dscConfig.AllNodes.Website
@@ -194,8 +194,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$dscConfig -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$dscConfig -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -206,7 +206,7 @@ try
         
         It 'Should remove the Website' -test {
             
-            Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$dscConfg  -OutputPath `$TestEnvironment.WorkingFolder"
+            Invoke-Expression -Command "$($script:DSCResourceName)_Absent -ConfigurationData `$dscConfg  -OutputPath `$TestDrive"
 
             # Build results to test
             $result = Get-Website -Name $dscConfig.AllNodes.Website

--- a/Tests/Integration/MSFT_xWebsiteDefaults.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebsiteDefaults.Integration.Tests.ps1
@@ -30,8 +30,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($script:DSCResourceName)_Config -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -53,8 +53,8 @@ try
                 -Filter 'system.applicationHost/sites/virtualDirectoryDefaults' `
                 -Name 'allowSubDirConfig').Value
 
-            Invoke-Expression -Command "$($script:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
-            Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+            Invoke-Expression -Command "$($script:DSCResourceName)_Config -OutputPath `$TestDrive"
+            Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
 
             $changedValue = (Get-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -filter 'system.applicationHost/sites/virtualDirectoryDefaults' -name 'allowSubDirConfig').Value
             $changedValue | should be $env:PesterVirtualDirectoryDefaults


### PR DESCRIPTION
Per PowerShell/DscResource.Tests#79 Install-ModuleFromPowerShellGallery from TestHelper.psm1 has been modified and 'WorkingFolder' has been removed from the test environment.

This PR fixes problems in this repo brought on by those changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/259)
<!-- Reviewable:end -->
