### PR TITLE
Fixed #260 changed LogTruncateSize validation for xIisLogging and xWebsite.

### DIFF
--- a/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
+++ b/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
@@ -6,7 +6,7 @@ data LocalizedData
 {
     # culture="en-US"
     ConvertFrom-StringData -StringData @'
-        VerboseGetTargetResult                     = Get-Taget has been run.
+        VerboseGetTargetResult                     = Get-TargetResource has been run.
         VerboseSetTargetUpdateLogPath              = LogPath is not in the desired state and will be updated.
         VerboseSetTargetUpdateLogFlags             = LogFlags do not match and will be updated.
         VerboseSetTargetUpdateLogPeriod            = LogPeriod is not in the desired state and will be updated.
@@ -73,8 +73,8 @@ function Set-TargetResource
         [ValidateSet('Hourly','Daily','Weekly','Monthly','MaxSize')]
         [String] $LogPeriod,
                 
-        [ValidateRange('1048576','4294967295')]
-        [String] $LogTruncateSize,
+        [ValidateRange(1048576,4294967295)]
+        [UInt64] $LogTruncateSize,
 
         [Boolean] $LoglocalTimeRollover,
         
@@ -176,9 +176,9 @@ function Test-TargetResource
                 
         [ValidateSet('Hourly','Daily','Weekly','Monthly','MaxSize')]
         [String] $LogPeriod,
-                
-        [ValidateRange('1048576','4294967295')]
-        [String] $LogTruncateSize,
+        
+        [ValidateRange(1048576,4294967295)]
+        [UInt64] $LogTruncateSize,
 
         [Boolean] $LoglocalTimeRollover,
         

--- a/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
+++ b/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
@@ -72,9 +72,11 @@ function Set-TargetResource
                 
         [ValidateSet('Hourly','Daily','Weekly','Monthly','MaxSize')]
         [String] $LogPeriod,
-                
-        [ValidateRange(1048576,4294967295)]
-        [UInt64] $LogTruncateSize,
+
+        [ValidateScript({
+            ([ValidateRange(1048576, 4294967295)] $valueAsUInt64 = [UInt64]::Parse($_))
+        })]
+        [String] $LogTruncateSize,
 
         [Boolean] $LoglocalTimeRollover,
         
@@ -176,9 +178,11 @@ function Test-TargetResource
                 
         [ValidateSet('Hourly','Daily','Weekly','Monthly','MaxSize')]
         [String] $LogPeriod,
-        
-        [ValidateRange(1048576,4294967295)]
-        [UInt64] $LogTruncateSize,
+
+        [ValidateScript({
+            ([ValidateRange(1048576, 4294967295)] $valueAsUInt64 = [UInt64]::Parse($_))
+        })]
+        [String] $LogTruncateSize,
 
         [Boolean] $LoglocalTimeRollover,
         

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -230,8 +230,10 @@ function Set-TargetResource
         [String]
         $LogPeriod,
 
-        [ValidateRange(1048576, 4294967295)]
-        [UInt64]
+        [ValidateScript({
+            ([ValidateRange(1048576, 4294967295)] $valueAsUInt64 = [UInt64]::Parse($_))
+        })]
+        [String]
         $LogTruncateSize,
 
         [Boolean]
@@ -817,8 +819,10 @@ function Test-TargetResource
         [String]
         $LogPeriod,
 
-        [ValidateRange(1048576, 4294967295)]
-        [UInt64]
+        [ValidateScript({
+            ([ValidateRange(1048576, 4294967295)] $valueAsUInt64 = [UInt64]::Parse($_))
+        })]
+        [String]
         $LogTruncateSize,
 
         [Boolean]

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -230,8 +230,8 @@ function Set-TargetResource
         [String]
         $LogPeriod,
 
-        [ValidateRange('1048576','4294967295')]
-        [String]
+        [ValidateRange(1048576, 4294967295)]
+        [UInt64]
         $LogTruncateSize,
 
         [Boolean]
@@ -817,8 +817,8 @@ function Test-TargetResource
         [String]
         $LogPeriod,
 
-        [ValidateRange('1048576','4294967295')]
-        [String]
+        [ValidateRange(1048576, 4294967295)]
+        [UInt64]
         $LogTruncateSize,
 
         [Boolean]

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Currently, only FastCgiModule is supported.
 ### Unreleased
 
 * Log directory configuration on **xWebsite** used the logPath attribute instead of the directory attribute. Bugfix for #256.
+* Changed validation of LogTruncateSize for **xIisLogging** and **xWebsite** to UInt64 validation.
 
 ### 1.15.0.0
 

--- a/Tests/Unit/MSFT_xIISLogging.tests.ps1
+++ b/Tests/Unit/MSFT_xIISLogging.tests.ps1
@@ -54,7 +54,7 @@ try
                     return $null
                 }
 
-                It 'should throw an error' {
+                It 'Should throw an error' {
                     { Assert-Module } | 
                     Should Throw
  
@@ -69,38 +69,38 @@ try
             Context 'Correct hashtable is returned' {
                 
                 Mock -CommandName Get-WebConfiguration `
-                    -MockWith { return $MockLogOutput } 
+                    -MockWith { return $MockLogOutput }
 
                 Mock -CommandName Assert-Module -MockWith {}
                     
                 $result = Get-TargetResource -LogPath $MockLogParameters.LogPath
                
-                It 'should call Get-WebConfiguration once' {
+                It 'Should call Get-WebConfiguration once' {
                     Assert-MockCalled -CommandName Get-WebConfiguration -Exactly 1
                 }
                 
-                It 'should return LogPath' {
-                    $Result.LogPath | Should Be $MockLogOutput.directory
+                It 'Should return LogPath' {
+                    $result.LogPath | Should Be $MockLogOutput.directory
                 }
                 
-                It 'should return LogFlags' {
-                    $Result.LogFlags | Should Be $MockLogOutput.logExtFileFlags
+                It 'Should return LogFlags' {
+                    $result.LogFlags | Should Be $MockLogOutput.logExtFileFlags
                 }
 
-                It 'should return LogPeriod' {
-                    $Result.LogPeriod | Should Be $MockLogOutput.period
+                It 'Should return LogPeriod' {
+                    $result.LogPeriod | Should Be $MockLogOutput.period
                 }
 
-                It 'should return LogTruncateSize' {
-                    $Result.LogTruncateSize | Should Be $MockLogOutput.truncateSize
+                It 'Should return LogTruncateSize' {
+                    $result.LogTruncateSize | Should Be $MockLogOutput.truncateSize
                 }
 
-                It 'should return LoglocalTimeRollover' {
-                    $Result.LoglocalTimeRollover | Should Be $MockLogOutput.localTimeRollover
+                It 'Should return LoglocalTimeRollover' {
+                    $result.LoglocalTimeRollover | Should Be $MockLogOutput.localTimeRollover
                 }
                 
-                It 'should return LogFormat' {
-                    $Result.LogFormat | Should Be $MockLogOutput.logFormat
+                It 'Should return LogFormat' {
+                    $result.LogFormat | Should Be $MockLogOutput.logFormat
                 }
                 
             }
@@ -117,12 +117,11 @@ try
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
                     }
-                
 
                 Mock -CommandName Test-Path -MockWith { return $true }
             
@@ -164,13 +163,12 @@ try
                     @{
                         directory         = '%SystemDrive%\inetpub\logs\LogFiles'
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
                     }
                 
-            
                 Mock -CommandName Test-Path -MockWith { return $true }
             
                 Mock -CommandName Get-WebConfiguration `
@@ -179,7 +177,6 @@ try
                 Mock -CommandName Get-WebConfigurationProperty `
                     -MockWith { return $MockLogOutput.logExtFileFlags }
 
-                
                 $result = Test-TargetResource @MockLogParameters
 
                 It 'Should return false' { 
@@ -194,7 +191,7 @@ try
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
@@ -210,7 +207,7 @@ try
                 
                 $result = Test-TargetResource @MockLogParameters
 
-                It 'Should return false' { 
+                It 'Should return false' {
                     $result | Should be $false
                 }
 
@@ -218,12 +215,12 @@ try
 
             Context 'Check LogPeriod should return false' {
 
-                $MockLogOutput = 
+                $MockLogOutput =
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
                         period            = 'Daily'
-                        truncateSize      = $MockLogParameters.LogTruncateSize 
+                        truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
                     }
@@ -250,7 +247,7 @@ try
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = '1048576'
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
@@ -266,7 +263,7 @@ try
                 
                 $result = Test-TargetResource @MockLogParameters
 
-                It 'Should return false' { 
+                It 'Should return false' {
                     $result | Should be $false
                 }
 
@@ -286,7 +283,7 @@ try
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = '636870912'
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
@@ -310,11 +307,11 @@ try
 
             Context 'Check LoglocalTimeRollover should return false' {
 
-                $MockLogOutput = 
+                $MockLogOutput =
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = 'False'
                         logFormat         = $MockLogParameters.LogFormat
@@ -330,7 +327,7 @@ try
                 
                 $result = Test-TargetResource @MockLogParameters
 
-                It 'Should return false' { 
+                It 'Should return false' {
                     $result | Should be $false
                 }
 
@@ -342,7 +339,7 @@ try
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = 'IIS'
@@ -358,7 +355,7 @@ try
                 
                 $result = Test-TargetResource @MockLogParameters
 
-                It 'Should return false' { 
+                It 'Should return false' {
                     $result | Should be $false
                 }
 
@@ -372,7 +369,7 @@ try
         
             Context 'All Settings are incorrect' {
 
-                $MockLogOutput = 
+                $MockLogOutput =
                     @{
                         directory         = '%SystemDrive%\inetpub\logs\LogFiles'
                         logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
@@ -385,16 +382,16 @@ try
                 Mock -CommandName Test-Path -MockWith { return $true }
             
                 Mock -CommandName Get-WebConfiguration `
-                    -MockWith { return $MockLogOutput } 
+                    -MockWith { return $MockLogOutput }
 
                 Mock -CommandName Get-WebConfigurationProperty `
-                    -MockWith { return $MockLogOutput.logExtFileFlags } 
+                    -MockWith { return $MockLogOutput.logExtFileFlags }
                 
                 Mock -CommandName Set-WebConfigurationProperty
                 
-                $result = Set-TargetResource @MockLogParameters
+                Set-TargetResource @MockLogParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 8
                 }
 
@@ -402,11 +399,11 @@ try
 
             Context 'LogPath is incorrect' {
 
-                $MockLogOutput = 
+                $MockLogOutput =
                     @{
                         directory         = '%SystemDrive%\inetpub\logs\LogFiles'
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
@@ -422,9 +419,9 @@ try
 
                 Mock -CommandName Set-WebConfigurationProperty
                 
-                $result = Set-TargetResource @MockLogParameters
+                Set-TargetResource @MockLogParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1
                 }
             
@@ -432,11 +429,11 @@ try
 
             Context 'LogFlags are incorrect' {
 
-                $MockLogOutput = 
+                $MockLogOutput =
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
@@ -452,9 +449,9 @@ try
                 
                 Mock -CommandName Set-WebConfigurationProperty
                 
-                $result = Set-TargetResource @MockLogParameters
+                Set-TargetResource @MockLogParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
                 }
 
@@ -467,11 +464,11 @@ try
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
                         period            = 'Daily'
-                        truncateSize      = $MockLogParameters.LogTruncateSize 
+                        truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
                     }
-                            
+                
                 Mock -CommandName Test-Path -MockWith { return $true }
             
                 Mock -CommandName Get-WebConfiguration `
@@ -482,9 +479,9 @@ try
                 
                 Mock -CommandName Set-WebConfigurationProperty
                 
-                $result = Set-TargetResource @MockLogParameters
+                Set-TargetResource @MockLogParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1
                 }
 
@@ -492,11 +489,11 @@ try
 
             Context 'LogTruncateSize is incorrect' {
 
-                $MockLogOutput = 
+                $MockLogOutput =
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = '1048576'
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
@@ -512,9 +509,9 @@ try
                 
                 Mock -CommandName Set-WebConfigurationProperty
                 
-                $result = Set-TargetResource @MockLogParameters
+                Set-TargetResource @MockLogParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
                 }
 
@@ -534,7 +531,7 @@ try
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = '1048576'
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = $MockLogParameters.LogFormat
@@ -550,7 +547,7 @@ try
                 
                 Mock -CommandName Set-WebConfigurationProperty
                 
-                $result = Set-TargetResource @MockLogParameters
+                Set-TargetResource @MockLogParameters
 
                 It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
@@ -568,7 +565,7 @@ try
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = 'False'
                         logFormat         = $MockLogParameters.LogFormat
@@ -584,9 +581,9 @@ try
                 
                 Mock -CommandName Set-WebConfigurationProperty
                 
-                $result = Set-TargetResource @MockLogParameters
+                Set-TargetResource @MockLogParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1
                 }
 
@@ -598,7 +595,7 @@ try
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                         logFormat         = 'IIS'
@@ -614,9 +611,9 @@ try
                 
                 Mock -CommandName Set-WebConfigurationProperty
                 
-                $result = Set-TargetResource @MockLogParameters
+                Set-TargetResource @MockLogParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 1
                 }
 
@@ -628,17 +625,17 @@ try
          
             Context 'Returns false when LogFlags are incorrect' {
                
-                $MockLogOutput = 
+                $MockLogOutput =
                     @{
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = @('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
                         logFormat         = 'W3C'
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                     }
                 
-                 Mock -CommandName Get-WebConfigurationProperty `
+                Mock -CommandName Get-WebConfigurationProperty `
                     -MockWith { return $MockLogOutput.logExtFileFlags }
                 
                 $result = Compare-LogFlags $MockLogParameters.LogFlags
@@ -656,7 +653,7 @@ try
                         directory         = $MockLogParameters.LogPath
                         logExtFileFlags   = $MockLogParameters.LogFlags
                         logFormat         = 'W3C'
-                        period            = $MockLogParameters.LogPeriod     
+                        period            = $MockLogParameters.LogPeriod
                         truncateSize      = $MockLogParameters.LogTruncateSize
                         localTimeRollover = $MockLogParameters.LoglocalTimeRollover
                     }
@@ -668,7 +665,7 @@ try
 
                 It 'Should return true' { 
                     $result | Should be $true
-                }        
+                }
             }
          
          }

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -817,13 +817,13 @@ try
             Context 'All properties need to be updated and website must be started' {
                 Mock -CommandName Add-WebConfiguration
 
-                Mock -CommandName Confirm-UniqueBinding -MockWith {return $true}
+                Mock -CommandName Confirm-UniqueBinding -MockWith { return $true }
 
-                Mock -CommandName Confirm-UniqueServiceAutoStartProviders -MockWith {return $false}
+                Mock -CommandName Confirm-UniqueServiceAutoStartProviders -MockWith { return $false }
 
-                Mock -CommandName Get-Website -MockWith {return $MockWebsite}
+                Mock -CommandName Get-Website -MockWith { return $MockWebsite }
 
-                Mock -CommandName Test-WebsiteBinding -MockWith {return $false}
+                Mock -CommandName Test-WebsiteBinding -MockWith { return $false }
 
                 Mock -CommandName Start-Website
 
@@ -849,9 +849,9 @@ try
                 Mock -CommandName Test-AuthenticationEnabled { return $false } `
                     -ParameterFilter { ($Type -eq 'Windows') }
 
-                $Result = Set-TargetResource @MockParameters
+                Set-TargetResource @MockParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                     Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                     Assert-MockCalled -CommandName Confirm-UniqueBinding -Exactly 1
                     Assert-MockCalled -CommandName Confirm-UniqueServiceAutoStartProviders -Exactly 1
@@ -952,9 +952,9 @@ try
                 Mock -CommandName Test-AuthenticationEnabled { return $false } `
                     -ParameterFilter { ($Type -eq 'Windows') }
 
-                $Result = Set-TargetResource @MockParameters
+                Set-TargetResource @MockParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 12
                     Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                     Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
@@ -1021,9 +1021,9 @@ try
                 Mock -CommandName Test-AuthenticationEnabled { return $false } `
                     -ParameterFilter { ($Type -eq 'Windows') }
 
-                $Result = Set-TargetResource @MockParameters
+                Set-TargetResource @MockParameters
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName New-Website -Exactly 1
                      Assert-MockCalled -CommandName Stop-Website -Exactly 1
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
@@ -1094,7 +1094,7 @@ try
                 Mock -CommandName Test-AuthenticationEnabled { return $false } `
                     -ParameterFilter { ($Type -eq 'Windows') }
 
-                $result = Set-TargetResource @MockParameters
+                Set-TargetResource @MockParameters
 
                 It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
@@ -1164,7 +1164,7 @@ try
                 Mock -CommandName Test-AuthenticationEnabled { return $false } `
                     -ParameterFilter { ($Type -eq 'Windows') }
 
-                $result = Set-TargetResource @MockParameters
+                Set-TargetResource @MockParameters
 
                 It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
@@ -1202,11 +1202,11 @@ try
                     }
                 }
 
-                Mock -CommandName New-Website -MockWith {return $MockWebsite}
+                Mock -CommandName New-Website -MockWith { return $MockWebsite }
 
                 Mock -CommandName Stop-Website
 
-                Mock -CommandName Test-WebsiteBinding -MockWith {return $false}
+                Mock -CommandName Test-WebsiteBinding -MockWith { return $false }
 
                 Mock -CommandName Update-WebsiteBinding
 
@@ -1216,14 +1216,14 @@ try
 
                 Mock -CommandName Update-DefaultPage
 
-                Mock -CommandName Confirm-UniqueBinding -MockWith {return $false}
+                Mock -CommandName Confirm-UniqueBinding -MockWith { return $false }
 
-                Mock -CommandName Confirm-UniqueServiceAutoStartProviders -MockWith {return $true}
+                Mock -CommandName Confirm-UniqueServiceAutoStartProviders -MockWith { return $true }
 
                 Mock -CommandName Start-Website
 
 
-                It 'should throw the correct error' {
+                It 'Should throw the correct error' {
                     $ErrorId = 'WebsiteBindingConflictOnStart'
                     $ErrorCategory = [System.Management.Automation.ErrorCategory]::InvalidResult
                     $ErrorMessage = $LocalizedData.ErrorWebsiteBindingConflictOnStart -f $MockParameters.Name
@@ -1283,7 +1283,7 @@ try
                 Mock -CommandName Get-WebConfigurationProperty `
                     -MockWith { return $MockLogOutput.logExtFileFlags }
 
-                $result = Set-TargetResource -Ensure $MockParameters.Ensure `
+                Set-TargetResource -Ensure $MockParameters.Ensure `
                     -Name $MockParameters.Name `
                     -PhysicalPath $MockParameters.PhysicalPath `
                     -LogTruncateSize '5000000' `
@@ -1304,20 +1304,20 @@ try
                 PhysicalPath = 'C:\NonExistent'
             }
 
-            Mock -CommandName Get-Website -MockWith {return @{Name = $MockParameters.Name}}
+            Mock -CommandName Get-Website -MockWith { return @{Name = $MockParameters.Name} }
 
             Mock -CommandName Assert-Module -MockWith {}
 
-            It 'should call Remove-Website' {
+            It 'Should call Remove-Website' {
                 Mock -CommandName Remove-Website
 
-                $Result = Set-TargetResource @MockParameters
+                Set-TargetResource @MockParameters
 
                 Assert-MockCalled -CommandName Get-Website -Exactly 1
                 Assert-MockCalled -CommandName Remove-Website -Exactly 1
             }
 
-            It 'should throw the correct error' {
+            It 'Should throw the correct error' {
                 Mock -CommandName Remove-Website -MockWith {throw}
 
                 $ErrorId = 'WebsiteRemovalFailure'


### PR DESCRIPTION
Changed the validation for LogTruncateSize for **xIisLogging** and **xWebsite**. This resolves #260. Opted not to change the MOF Schema, since this would be a breaking change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/261)
<!-- Reviewable:end -->
