### PR TITLE
xWebApplication comma seperates SSLFlags, fixes PowerShell/xWebAdministration#232

### DIFF
--- a/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
+++ b/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
@@ -184,7 +184,7 @@ function Set-TargetResource
                     Location = "${Website}/${Name}"
                     Filter   = 'system.webServer/security/access'
                     Name     = 'sslFlags'
-                    Value    = [string]$sslflags
+                    Value    = ($sslflags -join ',')
                 }
                 Set-WebConfigurationProperty @params
             }
@@ -729,17 +729,15 @@ function Test-SslFlags
         [String] $Location
     )
 
-
     $CurrentSslFlags =  Get-SslFlags -Location $Location
 
     if(Compare-Object -ReferenceObject $CurrentSslFlags `
                         -DifferenceObject $SslFlags)
-      {
-          return $false
-      }
-        
+    {
+        return $false
+    }
+
     return $true
-    
 }
 
 #endregion

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
+* Changed SSLFlags for **xWebApplication** to comma seperate multiple SSL flags, fixes #232.
+
 ### 1.16.0.0
 
 * Log directory configuration on **xWebsite** used the logPath attribute instead of the directory attribute. Bugfix for #256.


### PR DESCRIPTION
Updates to xWebApplication:

- [x] xWebApplication comma seperates SSLFlags, fixes PowerShell/xWebAdministration#232
- [x] Updated xWebApplication unit tests, the test for SSLFlags where not testing this property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/275)
<!-- Reviewable:end -->
