### PR TITLE
Adding a fix for LogPeriod always returning $false due to wrong test

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -459,7 +459,7 @@ function Set-TargetResource
 
             # Update LogPeriod if needed
             if ($PSBoundParameters.ContainsKey('LogPeriod') -and `
-                ($LogPeriod -ne $website.logfile.LogPeriod))
+                ($LogPeriod -ne $website.logfile.period))
             {
                 if ($PSBoundParameters.ContainsKey('LogTruncateSize'))
                     {
@@ -700,7 +700,7 @@ function Set-TargetResource
 
             # Update LogPeriod if needed
             if ($PSBoundParameters.ContainsKey('LogPeriod') -and `
-                ($LogPeriod -ne $website.logfile.LogPeriod))
+                ($LogPeriod -ne $website.logfile.period))
             {
                 if ($PSBoundParameters.ContainsKey('LogTruncateSize'))
                     {
@@ -1012,7 +1012,7 @@ function Test-TargetResource
 
         # Check LogPeriod
         if ($PSBoundParameters.ContainsKey('LogPeriod') -and `
-            ($LogPeriod -ne $website.logfile.LogPeriod))
+            ($LogPeriod -ne $website.logfile.period))
         {
             if ($PSBoundParameters.ContainsKey('LogTruncateSize'))
             {

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -551,14 +551,7 @@ try
             }
 
             Context 'Check LogFlags are different' {
-                $MockLogOutput = @{
-                    directory         = $MockParameters.LogPath
-                    logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
-                    logFormat         = $MockParameters.LogFormat
-                    period            = $MockParameters.LogPeriod
-                    truncateSize      = $MockParameters.LogTruncateSize
-                    localTimeRollover = $MockParameters.LoglocalTimeRollover
-                }
+                $MockLogOutput.logExtFileFlags = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
 
                 Mock -CommandName Test-Path -MockWith { return $true }
 
@@ -577,16 +570,30 @@ try
                     $result | Should be $false
                 }
             }
+            
+            Context 'Check LogPeriod is equal' {
+                $MockLogOutput.period = $MockParameters.LogPeriod
+
+                Mock -CommandName Test-Path -MockWith {Return $true}
+
+                Mock -CommandName Get-Website -MockWith {return $MockWebsite}
+
+                Mock -CommandName Get-WebConfigurationProperty `
+                    -MockWith {return $MockLogOutput.logExtFileFlags }
+
+                $Result = Test-TargetResource -Ensure $MockParameters.Ensure `
+                    -Name $MockParameters.Name `
+                    -PhysicalPath $MockParameters.PhysicalPath `
+                    -LogPeriod 'Hourly' `
+                    -Verbose:$VerbosePreference
+
+                It 'Should return true' {
+                    $result | Should be $true
+                }
+            }
 
             Context 'Check LogPeriod is different' {
-                $MockLogOutput = @{
-                        directory         = $MockParameters.LogPath
-                        logExtFileFlags   = $MockParameters.LogFlags
-                        logFormat         = $MockParameters.LogFormat
-                        period            = 'Daily'
-                        truncateSize      = $MockParameters.LogTruncateSize
-                        localTimeRollover = $MockParameters.LoglocalTimeRollover
-                    }
+                $MockLogOutput.period = 'Daily'
 
                 Mock -CommandName Test-Path -MockWith {Return $true}
 


### PR DESCRIPTION
I've noticed that `LogPeriod`, when configured on xWebSite, will always return `$false` (even when resource is configured as intended). 
It looks like test assumes `$webSite.LogFile.LogPeriod`, but the object returned by `Get-WebSite` contains property `period` instead. Adjusting it in both `Test` and `Set` (`Get` was fine for some reason...).

Also Pester tests for testing that property were incomplete and broken (overwriting `$MockLogOutput` with new hash table effectively "disconnects it" from `$MockWebSite`).

In this PR I'm trying to address both problems and add tests for correct LogPeriod returned from WebSite (that fail for currently used version of the module).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/277)
<!-- Reviewable:end -->
