### PR TITLE
Changed integration test of xWebsite to clean up self signed certificate, fixes #276

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
+* Added removal of self signed certificate to the integration tests of **xWebsite**, fixes #276.
+
 ### 1.16.0.0
 
 * Log directory configuration on **xWebsite** used the logPath attribute instead of the directory attribute. Bugfix for #256.

--- a/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
@@ -29,11 +29,12 @@ try
     $dscConfig = Import-LocalizedData -BaseDirectory $PSScriptRoot -FileName "$($script:DSCResourceName).config.psd1"
 
     # Create a SelfSigned Cert
-    $selfSignedCert = (New-SelfSignedCertificate -DnsName $dscConfig.AllNodes.HTTPSHostname  -CertStoreLocation 'cert:\LocalMachine\My')
+    $selfSignedCert = (New-SelfSignedCertificate -DnsName $dscConfig.AllNodes.HTTPSHostname `
+        -CertStoreLocation 'cert:\LocalMachine\My')
     
     #region HelperFunctions
 
-   # Function needed to test AuthenticationInfo
+    # Function needed to test AuthenticationInfo
     function Get-AuthenticationInfo
     {
         [CmdletBinding()]
@@ -63,7 +64,7 @@ try
             } | Should not throw
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
+        It 'Should be able to call Get-DscConfiguration without throwing' {
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion
@@ -131,7 +132,7 @@ try
             } | Should not throw
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
+        It 'Should be able to call Get-DscConfiguration without throwing' {
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion
@@ -199,7 +200,7 @@ try
             } | Should not throw
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
+        It 'Should be able to call Get-DscConfiguration without throwing' {
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion
@@ -238,6 +239,7 @@ finally
     #region FOOTER
     Restore-WebConfiguration -Name $tempName
     Remove-WebConfigurationBackup -Name $tempName
+    Remove-Item -PSPath $selfSignedCert.PSPath
 
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
     #endregion


### PR DESCRIPTION
Changed integration test of xWebsite to clean up self signed certificate, fixes #276 . It now removes the self signed certificate that it generates.