### PR TITLE
xWebSite: Fixed errors when setting log properties (issue #299)

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -431,18 +431,10 @@ function Set-TargetResource
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogFormat `
                                         -f $Name)
 
-                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.logFormat property
-                if ([Environment]::OSVersion.Version -ge '6.2')
-                {
-                    Set-ItemProperty -Path "IIS:\Sites\$Name" `
-                        -Name LogFile.logFormat -Value $LogFormat
-                }
-                else
-                {
-                    $site = Get-Item "IIS:\Sites\$Name"
-                    $site.LogFile.logFormat = $LogFormat
-                    $site | Set-Item
-                }
+                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.LogFormat property
+                $site = Get-Item "IIS:\Sites\$Name"
+                $site.LogFile.LogFormat = $LogFormat
+                $site | Set-Item
             }
 
             # Update LogFlags if required
@@ -454,7 +446,7 @@ function Set-TargetResource
 
                 # Set-ItemProperty has no effect with the LogFile.LogExtFileFlags property
                 $site = Get-Item "IIS:\Sites\$Name"
-                $site.LogFile.logFormat = 'W3C'
+                $site.LogFile.LogFormat = 'W3C'
                 $site.LogFile.LogExtFileFlags = $LogFlags -join ','
                 $site | Set-Item
             }
@@ -480,18 +472,10 @@ function Set-TargetResource
 
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogPeriod)
 
-                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.period property
-                if ([Environment]::OSVersion.Version -ge '6.2')
-                {
-                    Set-ItemProperty -Path "IIS:\Sites\$Name" `
-                        -Name LogFile.period -Value $LogPeriod
-                }
-                else
-                {
-                    $site = Get-Item "IIS:\Sites\$Name"
-                    $site.LogFile.period = $LogPeriod
-                    $site | Set-Item
-                }
+                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.Period property
+                $site = Get-Item "IIS:\Sites\$Name"
+                $site.LogFile.Period = $LogPeriod
+                $site | Set-Item
             }
 
             # Update LogTruncateSize if needed
@@ -509,7 +493,7 @@ function Set-TargetResource
             # Update LoglocalTimeRollover if neeed
             if ($PSBoundParameters.ContainsKey('LoglocalTimeRollover') -and `
                 ($LoglocalTimeRollover -ne `
-                 ([System.Convert]::ToBoolean($website.logFile.localTimeRollover))))
+                 ([System.Convert]::ToBoolean($website.logfile.LocalTimeRollover))))
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLoglocalTimeRollover `
                                         -f $Name)
@@ -694,18 +678,10 @@ function Set-TargetResource
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogFormat -f $Name)
                 
-                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.logFormat property
-                if ([Environment]::OSVersion.Version -ge '6.2')
-                {
-                    Set-ItemProperty -Path "IIS:\Sites\$Name" `
-                        -Name LogFile.logFormat -Value $LogFormat
-                }
-                else
-                {
-                    $site = Get-Item "IIS:\Sites\$Name"
-                    $site.LogFile.logFormat = $LogFormat
-                    $site | Set-Item
-                }
+                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.LogFormat property
+                $site = Get-Item "IIS:\Sites\$Name"
+                $site.LogFile.LogFormat = $LogFormat
+                $site | Set-Item
             }
 
             # Update LogFlags if required
@@ -717,7 +693,7 @@ function Set-TargetResource
 
                 # Set-ItemProperty has no effect with the LogFile.LogExtFileFlags property
                 $site = Get-Item "IIS:\Sites\$Name"
-                $site.LogFile.logFormat = 'W3C'
+                $site.LogFile.LogFormat = 'W3C'
                 $site.LogFile.LogExtFileFlags = $LogFlags -join ','
                 $site | Set-Item
             }
@@ -745,18 +721,10 @@ function Set-TargetResource
 
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogPeriod)
                 
-                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.period property
-                if ([Environment]::OSVersion.Version -ge '6.2')
-                {
-                    Set-ItemProperty -Path "IIS:\Sites\$Name" `
-                        -Name LogFile.period -Value $LogPeriod
-                }
-                else
-                {
-                    $site = Get-Item "IIS:\Sites\$Name"
-                    $site.LogFile.period = $LogPeriod
-                    $site | Set-Item
-                }
+                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.Period property
+                $site = Get-Item "IIS:\Sites\$Name"
+                $site.LogFile.Period = $LogPeriod
+                $site | Set-Item
             }
 
             # Update LogTruncateSize if needed
@@ -774,7 +742,7 @@ function Set-TargetResource
             # Update LoglocalTimeRollover if neeed
             if ($PSBoundParameters.ContainsKey('LoglocalTimeRollover') -and `
                 ($LoglocalTimeRollover -ne `
-                 ([System.Convert]::ToBoolean($website.logFile.localTimeRollover))))
+                 ([System.Convert]::ToBoolean($website.logfile.LocalTimeRollover))))
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLoglocalTimeRollover `
                                         -f $Name)
@@ -1083,7 +1051,7 @@ function Test-TargetResource
         # Check LoglocalTimeRollover
         if ($PSBoundParameters.ContainsKey('LoglocalTimeRollover') -and `
             ($LoglocalTimeRollover -ne `
-            ([System.Convert]::ToBoolean($website.logFile.localTimeRollover))))
+            ([System.Convert]::ToBoolean($website.logfile.LocalTimeRollover))))
         {
             Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalseLoglocalTimeRollover `
                                     -f $Name)

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -441,10 +441,12 @@ function Set-TargetResource
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogFlags `
                                         -f $Name)
-                Set-ItemProperty -Path "IIS:\Sites\$Name" `
-                    -Name LogFile.logFormat -Value 'W3C'
-                Set-ItemProperty -Path "IIS:\Sites\$Name" `
-                    -Name LogFile.LogExtFileFlags -Value ($LogFlags -join ',')
+
+                # Set-ItemProperty has no effect with the LogFile.LogExtFileFlags property
+                $site = Get-Item "IIS:\Sites\$Name"
+                $site.LogFile.logFormat = 'W3C'
+                $site.LogFile.LogExtFileFlags = $LogFlags -join ','
+                $site | Set-Item
             }
 
             # Update LogPath if required
@@ -467,8 +469,19 @@ function Set-TargetResource
                     }
 
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogPeriod)
-                Set-ItemProperty -Path "IIS:\Sites\$Name" `
-                    -Name LogFile.period -Value $LogPeriod
+
+                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.period property
+                if ([Environment]::OSVersion.Version -ge '6.2')
+                {
+                    Set-ItemProperty -Path "IIS:\Sites\$Name" `
+                        -Name LogFile.period -Value $LogPeriod
+                }
+                else
+                {
+                    $site = Get-Item "IIS:\Sites\$Name"
+                    $site.LogFile.period = $LogPeriod
+                    $site | Set-Item
+                }
             }
 
             # Update LogTruncateSize if needed
@@ -681,10 +694,12 @@ function Set-TargetResource
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogFlags `
                                         -f $Name)
-                Set-ItemProperty -Path "IIS:\Sites\$Name" `
-                    -Name LogFile.logFormat -Value 'W3C'
-                Set-ItemProperty -Path "IIS:\Sites\$Name" `
-                    -Name LogFile.LogExtFileFlags -Value ($LogFlags -join ',')
+
+                # Set-ItemProperty has no effect with the LogFile.LogExtFileFlags property
+                $site = Get-Item "IIS:\Sites\$Name"
+                $site.LogFile.logFormat = 'W3C'
+                $site.LogFile.LogExtFileFlags = $LogFlags -join ','
+                $site | Set-Item
             }
 
             # Update LogPath if required
@@ -709,8 +724,19 @@ function Set-TargetResource
                     }
 
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogPeriod)
-                Set-ItemProperty -Path "IIS:\Sites\$Name" `
-                    -Name LogFile.period -Value $LogPeriod
+                
+                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.period property
+                if ([Environment]::OSVersion.Version -ge '6.2')
+                {
+                    Set-ItemProperty -Path "IIS:\Sites\$Name" `
+                        -Name LogFile.period -Value $LogPeriod
+                }
+                else
+                {
+                    $site = Get-Item "IIS:\Sites\$Name"
+                    $site.LogFile.period = $LogPeriod
+                    $site | Set-Item
+                }
             }
 
             # Update LogTruncateSize if needed

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -430,9 +430,19 @@ function Set-TargetResource
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogFormat `
                                         -f $Name)
-                Set-WebConfigurationProperty '/system.applicationHost/sites/siteDefaults/logfile' `
-                    -Name logFormat `
-                    -Value $LogFormat
+
+                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.logFormat property
+                if ([Environment]::OSVersion.Version -ge '6.2')
+                {
+                    Set-ItemProperty -Path "IIS:\Sites\$Name" `
+                        -Name LogFile.logFormat -Value $LogFormat
+                }
+                else
+                {
+                    $site = Get-Item "IIS:\Sites\$Name"
+                    $site.LogFile.logFormat = $LogFormat
+                    $site | Set-Item
+                }
             }
 
             # Update LogFlags if required
@@ -499,7 +509,7 @@ function Set-TargetResource
             # Update LoglocalTimeRollover if neeed
             if ($PSBoundParameters.ContainsKey('LoglocalTimeRollover') -and `
                 ($LoglocalTimeRollover -ne `
-                 ([System.Convert]::ToBoolean($website.logfile.LoglocalTimeRollover))))
+                 ([System.Convert]::ToBoolean($website.logFile.localTimeRollover))))
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLoglocalTimeRollover `
                                         -f $Name)
@@ -683,9 +693,19 @@ function Set-TargetResource
                 ($LogFormat -ne $website.logfile.LogFormat))
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogFormat -f $Name)
-                Set-WebConfigurationProperty '/system.applicationHost/sites/siteDefaults/logfile' `
-                    -name logFormat `
-                    -value $LogFormat
+                
+                # In Windows Server 2008 R2, Set-ItemProperty only accepts index values to the LogFile.logFormat property
+                if ([Environment]::OSVersion.Version -ge '6.2')
+                {
+                    Set-ItemProperty -Path "IIS:\Sites\$Name" `
+                        -Name LogFile.logFormat -Value $LogFormat
+                }
+                else
+                {
+                    $site = Get-Item "IIS:\Sites\$Name"
+                    $site.LogFile.logFormat = $LogFormat
+                    $site | Set-Item
+                }
             }
 
             # Update LogFlags if required
@@ -754,7 +774,7 @@ function Set-TargetResource
             # Update LoglocalTimeRollover if neeed
             if ($PSBoundParameters.ContainsKey('LoglocalTimeRollover') -and `
                 ($LoglocalTimeRollover -ne `
-                 ([System.Convert]::ToBoolean($website.logfile.LoglocalTimeRollover))))
+                 ([System.Convert]::ToBoolean($website.logFile.localTimeRollover))))
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLoglocalTimeRollover `
                                         -f $Name)
@@ -1063,7 +1083,7 @@ function Test-TargetResource
         # Check LoglocalTimeRollover
         if ($PSBoundParameters.ContainsKey('LoglocalTimeRollover') -and `
             ($LoglocalTimeRollover -ne `
-            ([System.Convert]::ToBoolean($website.logfile.LoglocalTimeRollover))))
+            ([System.Convert]::ToBoolean($website.logFile.localTimeRollover))))
         {
             Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalseLoglocalTimeRollover `
                                     -f $Name)

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
+* xWebsite:
+  * Fixed bug when setting LogPeriod in IIS 7.5 and LogFlags in any platform, fixes #299.
+
 ### 1.17.0.0
 
 * Added removal of self signed certificate to the integration tests of **xWebsite**, fixes #276.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### Unreleased
 
 * xWebsite:
-  * Fixed bug when setting LogPeriod in IIS 7.5 and LogFlags in any platform, fixes #299.
+  * Fixed bugs when setting log properties, fixes #299.
 
 ### 1.17.0.0
 

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -819,6 +819,10 @@ try
                 LogFile              = $MockLogOutput
             }
 
+            $MockWebsiteGetItem = $MockWebsite.Clone()
+            $MockWebsiteGetItem.Path = 'WebAdministration::\\SERVERNAME\Sites\MockName'
+            $MockWebsiteGetItem = [PSCustomObject]$MockWebsiteGetItem
+
             Mock -CommandName Assert-Module -MockWith {}
 
             Context 'All properties need to be updated and website must be started' {
@@ -833,6 +837,10 @@ try
                 Mock -CommandName Test-WebsiteBinding -MockWith { return $false }
 
                 Mock -CommandName Start-Website
+
+                Mock -CommandName Get-Item -MockWith { return $MockWebsiteGetItem }
+                
+                Mock -CommandName Set-Item
 
                 Mock -CommandName Set-ItemProperty
 
@@ -867,7 +875,9 @@ try
                     Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
                     Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1
                     Assert-MockCalled -CommandName Set-Authentication -Exactly 4
-                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 12
+                    Assert-MockCalled -CommandName Get-Item -Exactly 1
+                    Assert-MockCalled -CommandName Set-Item -Exactly 1
+                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 10
                     Assert-MockCalled -CommandName Start-Website -Exactly 1
                 }
             }
@@ -882,6 +892,10 @@ try
                 Mock -CommandName New-Website -MockWith { return $MockWebsite } 
 
                 Mock -CommandName Start-Website
+
+                Mock -CommandName Get-Item -MockWith { return $MockWebsiteGetItem }
+                
+                Mock -CommandName Set-Item
 
                 Mock -CommandName Set-ItemProperty
                                 
@@ -906,6 +920,10 @@ try
                 Mock -CommandName New-Website -MockWith { return $MockWebsite } 
 
                 Mock -CommandName Start-Website
+
+                Mock -CommandName Get-Item -MockWith { return $MockWebsiteGetItem }
+                
+                Mock -CommandName Set-Item
 
                 Mock -CommandName Set-ItemProperty
                                 
@@ -1011,7 +1029,7 @@ try
                 Set-TargetResource @MockParameters
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 12
+                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 10
                     Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                     Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                     Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
@@ -1033,6 +1051,10 @@ try
                     LogFile                  = $MockLogOutput
                 }
 
+                $MockWebsiteGetItem = $MockWebsite.Clone()
+                $MockWebsiteGetItem.Path = 'WebAdministration::\\SERVERNAME\Sites\MockName'
+                $MockWebsiteGetItem = [PSCustomObject]$MockWebsiteGetItem
+
                 Mock -CommandName Get-Website
 
                 Mock -CommandName Get-Command -MockWith {
@@ -1050,6 +1072,10 @@ try
                 Mock -CommandName Test-WebsiteBinding -MockWith { return $false }
 
                 Mock -CommandName Update-WebsiteBinding
+
+                Mock -CommandName Get-Item -MockWith { return $MockWebsiteGetItem }
+                
+                Mock -CommandName Set-Item
 
                 Mock -CommandName Set-ItemProperty
 
@@ -1084,7 +1110,9 @@ try
                      Assert-MockCalled -CommandName Stop-Website -Exactly 1
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
-                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 10
+                     Assert-MockCalled -CommandName Get-Item -Exactly 1
+                     Assert-MockCalled -CommandName Set-Item -Exactly 1
+                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 8
                      Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                      Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1
                      Assert-MockCalled -CommandName Confirm-UniqueBinding -Exactly 1
@@ -1114,6 +1142,10 @@ try
                     }
                 }
 
+                $MockWebsiteGetItem = $MockWebsite.Clone()
+                $MockWebsiteGetItem.Path = 'WebAdministration::\\SERVERNAME\Sites\MockName'
+                $MockWebsiteGetItem = [PSCustomObject]$MockWebsiteGetItem
+
                 Mock -CommandName Get-Website -MockWith { return $MockWebsite }
 
                 Mock -CommandName Get-Command -MockWith {
@@ -1127,6 +1159,10 @@ try
                 Mock -CommandName Test-WebsiteBinding -MockWith { return $false }
 
                 Mock -CommandName Update-WebsiteBinding
+
+                Mock -CommandName Get-Item -MockWith { return $MockWebsiteGetItem }
+                
+                Mock -CommandName Set-Item
 
                 Mock -CommandName Set-ItemProperty
 
@@ -1155,7 +1191,9 @@ try
                 It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
-                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 8
+                     Assert-MockCalled -CommandName Get-Item -Exactly 1
+                     Assert-MockCalled -CommandName Set-Item -Exactly 1
+                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 6
                      Assert-MockCalled -CommandName Set-ItemProperty -ParameterFilter { $Name -eq 'LogFile.directory' } -Exactly 0
                      Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                      Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1
@@ -1184,6 +1222,10 @@ try
                     }
                 }
 
+                $MockWebsiteGetItem = $MockWebsite.Clone()
+                $MockWebsiteGetItem.Path = 'WebAdministration::\\SERVERNAME\Sites\MockName'
+                $MockWebsiteGetItem = [PSCustomObject]$MockWebsiteGetItem
+
                 Mock -CommandName Get-Website -MockWith { return $MockWebsite }
 
                 Mock -CommandName Get-Command -MockWith {
@@ -1197,6 +1239,10 @@ try
                 Mock -CommandName Test-WebsiteBinding -MockWith { return $false }
 
                 Mock -CommandName Update-WebsiteBinding
+
+                Mock -CommandName Get-Item -MockWith { return $MockWebsiteGetItem }
+                
+                Mock -CommandName Set-Item
 
                 Mock -CommandName Set-ItemProperty
 
@@ -1225,7 +1271,9 @@ try
                 It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
-                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 9
+                     Assert-MockCalled -CommandName Get-Item -Exactly 1
+                     Assert-MockCalled -CommandName Set-Item -Exactly 1
+                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 7
                      Assert-MockCalled -CommandName Set-ItemProperty -ParameterFilter { $Name -eq 'LogFile.directory' } -Exactly 1
                      Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                      Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -877,7 +877,7 @@ try
                     Assert-MockCalled -CommandName Set-Authentication -Exactly 4
                     Assert-MockCalled -CommandName Get-Item -Exactly 1
                     Assert-MockCalled -CommandName Set-Item -Exactly 1
-                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 10
+                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 11
                     Assert-MockCalled -CommandName Start-Website -Exactly 1
                 }
             }

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -875,9 +875,9 @@ try
                     Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
                     Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1
                     Assert-MockCalled -CommandName Set-Authentication -Exactly 4
-                    Assert-MockCalled -CommandName Get-Item -Exactly 1
-                    Assert-MockCalled -CommandName Set-Item -Exactly 1
-                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 11
+                    Assert-MockCalled -CommandName Get-Item -Exactly 3
+                    Assert-MockCalled -CommandName Set-Item -Exactly 3
+                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 9
                     Assert-MockCalled -CommandName Start-Website -Exactly 1
                 }
             }
@@ -1029,7 +1029,7 @@ try
                 Set-TargetResource @MockParameters
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 10
+                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly 9
                     Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                     Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                     Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
@@ -1112,7 +1112,7 @@ try
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Get-Item -Exactly 1
                      Assert-MockCalled -CommandName Set-Item -Exactly 1
-                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 8
+                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 7
                      Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                      Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1
                      Assert-MockCalled -CommandName Confirm-UniqueBinding -Exactly 1
@@ -1191,9 +1191,9 @@ try
                 It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
-                     Assert-MockCalled -CommandName Get-Item -Exactly 1
-                     Assert-MockCalled -CommandName Set-Item -Exactly 1
-                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 6
+                     Assert-MockCalled -CommandName Get-Item -Exactly 2
+                     Assert-MockCalled -CommandName Set-Item -Exactly 2
+                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 5
                      Assert-MockCalled -CommandName Set-ItemProperty -ParameterFilter { $Name -eq 'LogFile.directory' } -Exactly 0
                      Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                      Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1
@@ -1271,9 +1271,9 @@ try
                 It 'Should call all the mocks' {
                      Assert-MockCalled -CommandName Test-WebsiteBinding -Exactly 1
                      Assert-MockCalled -CommandName Update-WebsiteBinding -Exactly 1
-                     Assert-MockCalled -CommandName Get-Item -Exactly 1
-                     Assert-MockCalled -CommandName Set-Item -Exactly 1
-                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 7
+                     Assert-MockCalled -CommandName Get-Item -Exactly 2
+                     Assert-MockCalled -CommandName Set-Item -Exactly 2
+                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 6
                      Assert-MockCalled -CommandName Set-ItemProperty -ParameterFilter { $Name -eq 'LogFile.directory' } -Exactly 1
                      Assert-MockCalled -CommandName Add-WebConfiguration -Exactly 1
                      Assert-MockCalled -CommandName Update-DefaultPage -Exactly 1


### PR DESCRIPTION
Fixes the _Hourly is not a valid value for Int32_ error when setting the xWebSite LogPeriod in IIS 7.5. The solution was to set the value using numbers instead of strings when the OS version is prior to Windows Server 2012.

Fixes #299

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/300)
<!-- Reviewable:end -->
