### PR TITLE
Fix issue #314

### DIFF
--- a/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
+++ b/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
@@ -580,7 +580,7 @@ function Get-AuthenticationInfo
     $authenticationProperties = @{}
     foreach ($type in @('Anonymous', 'Basic', 'Digest', 'Windows'))
     {
-        $authenticationProperties[$type] = [bool](Test-AuthenticationEnabled -Site $Site `
+        $authenticationProperties[$type] = [Boolean](Test-AuthenticationEnabled -Site $Site `
                                                                                -Name $Name `
                                                                                -Type $type)
     }

--- a/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
+++ b/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
@@ -580,14 +580,15 @@ function Get-AuthenticationInfo
     $authenticationProperties = @{}
     foreach ($type in @('Anonymous', 'Basic', 'Digest', 'Windows'))
     {
-        $authenticationProperties[$type] = [String](Test-AuthenticationEnabled -Site $Site `
+        $authenticationProperties[$type] = [bool](Test-AuthenticationEnabled -Site $Site `
                                                                                -Name $Name `
                                                                                -Type $type)
     }
 
     return New-CimInstance `
             -ClassName MSFT_xWebApplicationAuthenticationInformation `
-            -ClientOnly -Property $authenticationProperties
+            -ClientOnly -Property $authenticationProperties `
+            -NameSpace 'root\microsoft\windows\desiredstateconfiguration'
             
 }
 
@@ -599,7 +600,8 @@ function Get-DefaultAuthenticationInfo
 {
     New-CimInstance -ClassName MSFT_xWebApplicationAuthenticationInformation `
         -ClientOnly `
-        -Property @{Anonymous=$false;Basic=$false;Digest=$false;Windows=$false}
+        -Property @{Anonymous=$false;Basic=$false;Digest=$false;Windows=$false} `
+        -NameSpace 'root\microsoft\windows\desiredstateconfiguration'
 }
 
 <#

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -1659,13 +1659,14 @@ function Get-AuthenticationInfo
     $authenticationProperties = @{}
     foreach ($type in @('Anonymous', 'Basic', 'Digest', 'Windows'))
     {
-        $authenticationProperties[$type] = [String](Test-AuthenticationEnabled -Site $Site `
+        $authenticationProperties[$type] = [Boolean](Test-AuthenticationEnabled -Site $Site `
                                                                                -Type $type)
     }
 
     return New-CimInstance `
             -ClassName MSFT_xWebAuthenticationInformation `
-            -ClientOnly -Property $authenticationProperties
+            -ClientOnly -Property $authenticationProperties `
+            -NameSpace 'root\microsoft\windows\desiredstateconfiguration'
 }
 
 <#

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -1677,7 +1677,8 @@ function Get-DefaultAuthenticationInfo
 {
     New-CimInstance -ClassName MSFT_xWebAuthenticationInformation `
         -ClientOnly `
-        -Property @{ Anonymous = $false; Basic = $false; Digest = $false; Windows = $false }
+        -Property @{ Anonymous = $false; Basic = $false; Digest = $false; Windows = $false } `
+        -NameSpace 'root\microsoft\windows\desiredstateconfiguration'
 }
 
 <#

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased
+* Fix Get-DSCLocalconfiguration failure with xWebApplication and xWebSite resources (Fix #314).
 
 ### 1.19.0.0
 

--- a/Tests/Unit/MSFT_xWebApplication.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebApplication.Tests.ps1
@@ -1195,7 +1195,7 @@ try
 
                 $GetWebConfigurationOutput = @(
                     @{
-                        Value = 'False'
+                        Value = $false
                     }
                 )
 
@@ -1204,10 +1204,10 @@ try
                 
                 It 'should all be false' {
                     $result = Get-AuthenticationInfo -site $MockParameters.Website -name $MockParameters.Name 
-                    $result.Anonymous | Should be False
-                    $result.Digest | Should be False
-                    $result.Basic | Should be False
-                    $result.Windows | Should be False
+                    $result.Anonymous | Should be $false
+                    $result.Digest | Should be $false
+                    $result.Basic | Should be $false
+                    $result.Windows | Should be $false
                 }
 
                 It 'should call Get-WebConfigurationProperty four times' {

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -2354,7 +2354,7 @@ try
             Context 'AuthenticationInfo is false' {
                 $MockWebConfiguration = @(
                     @{
-                        Value = 'False'
+                        Value = $false
                     }
                 )
 
@@ -2362,10 +2362,10 @@ try
 
                 It 'should all be false' {
                     $result = Get-AuthenticationInfo -site $MockWebsite.Name
-                    $result.Anonymous | Should be False
-                    $result.Digest | Should be False
-                    $result.Basic | Should be False
-                    $result.Windows | Should be False
+                    $result.Anonymous | Should be $false
+                    $result.Digest | Should be $false
+                    $result.Basic | Should be $false
+                    $result.Windows | Should be $false
                 }
 
                 It 'should call Get-WebConfigurationProperty four times' {


### PR DESCRIPTION
- [x] Helper method of the resource was returning a string type even though the schema of the MSFT_xWebApplicationAuthenticationInformation is expecting Boolean values.

- [x] Include the namespace 'root\microsoft\windows\desiredstateconfiguration' when creating the cim instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/335)
<!-- Reviewable:end -->
