### PR TITLE
Added LogCustomFields to xWebSite (Fixes #267)

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -49,6 +49,7 @@ data LocalizedData
         VerboseSetTargetUpdateLogTruncateSize = TruncateSize does not match and will be updated on Website "{0}".
         VerboseSetTargetUpdateLoglocalTimeRollover = LoglocalTimeRollover does not match and will be updated on Website "{0}".
         VerboseSetTargetUpdateLogFormat = LogFormat is not in the desired state and will be updated on Website "{0}"
+        VerboseSetTargetUpdateLogCustomFields = LogCustomFields is not in the desired state and will be updated on Website "{0}"
         VerboseTestTargetFalseEnsure = The Ensure state for website "{0}" does not match the desired state.
         VerboseTestTargetFalsePhysicalPath = Physical Path of website "{0}" does not match the desired state.
         VerboseTestTargetFalseState = The state of website "{0}" does not match the desired state.
@@ -69,6 +70,7 @@ data LocalizedData
         VerboseTestTargetFalseLogTruncateSize = LogTruncateSize does not match desired state on Website "{0}".
         VerboseTestTargetFalseLoglocalTimeRollover = LoglocalTimeRollover does not match desired state on Website "{0}".
         VerboseTestTargetFalseLogFormat = LogFormat does not match desired state on Website "{0}".
+        VerboseTestTargetFalseLogCustomFields = LogCustomFields does not match desired state on Website "{0}".
         VerboseConvertToWebBindingIgnoreBindingInformation = BindingInformation is ignored for bindings of type "{0}" in case at least one of the following properties is specified: IPAddress, Port, HostName.
         VerboseConvertToWebBindingDefaultPort = Port is not specified. The default "{0}" port "{1}" will be used.
         VerboseConvertToWebBindingDefaultCertificateStoreName = CertificateStoreName is not specified. The default value "{0}" will be used.
@@ -130,6 +132,8 @@ function Get-TargetResource
         $webConfiguration = $websiteAutoStartProviders | `
                                 Where-Object -Property Name -eq -Value $ServiceAutoStartProvider | `
                                 Select-Object Name,Type
+        
+        $cimLogCustomFields = @(ConvertTo-CimLogCustomFields -InputObject $website.logFile.customFields.Collection)
     }
     # Multiple websites with the same name exist. This is not supported and is an error
     else
@@ -161,6 +165,7 @@ function Get-TargetResource
         LogtruncateSize          = $website.logfile.truncateSize
         LoglocalTimeRollover     = $website.logfile.localTimeRollover
         LogFormat                = $website.logfile.logFormat
+        LogCustomFields          = $cimLogCustomFields
     }
 }
 
@@ -244,7 +249,10 @@ function Set-TargetResource
 
         [ValidateSet('IIS','W3C','NCSA')]
         [String]
-        $LogFormat
+        $LogFormat,
+
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $LogCustomFields
     )
 
     Assert-Module
@@ -502,6 +510,14 @@ function Set-TargetResource
                     -Name LogFile.localTimeRollover -Value $LoglocalTimeRollover
             }
 
+            # Update LogCustomFields if neeed
+            if ($PSBoundParameters.ContainsKey('LogCustomFields') -and `
+                (-not (Test-LogCustomField -Site $Name -LogCustomField $LogCustomFields)))
+            {
+                Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogCustomFields `
+                                        -f $Name)
+                Set-LogCustomField -Site $Name -LogCustomField $LogCustomFields
+            }
         }
         # Create website if it does not exist
         else
@@ -750,6 +766,15 @@ function Set-TargetResource
                 Set-ItemProperty -Path "IIS:\Sites\$Name" `
                     -Name LogFile.localTimeRollover -Value $LoglocalTimeRollover
             }
+
+            # Update LogCustomFields if neeed
+            if ($PSBoundParameters.ContainsKey('LogCustomFields') -and `
+                (-not (Test-LogCustomField -Site $Name -LogCustomField $LogCustomFields)))
+            {
+                Write-Verbose -Message ($LocalizedData.VerboseSetTargetUpdateLogCustomFields `
+                                        -f $Name)
+                Set-LogCustomField -Site $Name -LogCustomField $LogCustomFields
+            }
         }
     }
     # Remove website
@@ -850,7 +875,10 @@ function Test-TargetResource
 
         [ValidateSet('IIS','W3C','NCSA')]
         [String]
-        $LogFormat
+        $LogFormat,
+
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $LogCustomFields
     )
 
     Assert-Module
@@ -1055,6 +1083,15 @@ function Test-TargetResource
             ([System.Convert]::ToBoolean($website.logfile.LocalTimeRollover))))
         {
             Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalseLoglocalTimeRollover `
+                                    -f $Name)
+            return $false
+        }
+
+        # Check LogCustomFields if neeed
+        if ($PSBoundParameters.ContainsKey('LogCustomFields') -and `
+            (-not (Test-LogCustomField -Site $Name -LogCustomField $LogCustomFields)))
+        {
+            Write-Verbose -Message ($LocalizedData.VerboseTestTargetUpdateLogCustomFields `
                                     -f $Name)
             return $false
         }
@@ -1588,6 +1625,44 @@ function ConvertTo-WebBinding
 }
 
 <#
+        .SYNOPSIS
+        Converts IIS custom log field collection to instances of the MSFT_xLogCustomFieldInformation CIM class.
+#>
+function ConvertTo-CimLogCustomFields
+{
+    [CmdletBinding()]
+    [OutputType([Microsoft.Management.Infrastructure.CimInstance])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [AllowNull()]
+        [Object[]]
+        $InputObject
+    )
+    
+    $cimClassName = 'MSFT_xLogCustomFieldInformation'
+    $cimNamespace = 'root/microsoft/Windows/DesiredStateConfiguration'
+    $cimCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+    
+    foreach ($customField in $InputObject)
+    {
+        $cimProperties = @{
+            LogFieldName = $customField.LogFieldName
+            SourceName   = $customField.SourceName
+            SourceType   = $customField.SourceType
+        }
+
+        $cimCollection += (New-CimInstance -ClassName $cimClassName `
+                        -Namespace $cimNamespace `
+                        -Property $cimProperties `
+                        -ClientOnly)
+    }
+
+    return $cimCollection
+}
+
+<#
         .SYNOPSYS
         Formats the input IP address string for use in the bindingInformation attribute.
 #>
@@ -1742,6 +1817,52 @@ function Set-AuthenticationInfo
     {
         $enabled = ($AuthenticationInfo.CimInstanceProperties[$type].Value -eq $true)
         Set-Authentication -Site $Site -Type $type -Enabled $enabled
+    }
+}
+
+<#
+        .SYNOPSIS
+        Helper function used to set the LogCustomField for a website.
+
+        .PARAMETER Site
+        Specifies the name of the Website.
+
+        .PARAMETER LogCustomField
+        A CimInstance collection of what the LogCustomField should be.
+#>
+function Set-LogCustomField
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Site,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $LogCustomField
+    )
+
+    foreach ($customField in $LogCustomField)
+    {
+        $filterString = "/system.applicationHost/sites/site[@name='{0}']/logFile/customFields/add[@logFieldName='{1}']" -f $Site, $customField.LogFieldName
+
+        $presentCustomLog = Get-WebConfigurationProperty -Filter $filterString -Name "."
+        if ($presentCustomLog)
+        {
+            Clear-WebConfiguration -Filter $filterString
+        }
+
+        $addFilterString = "/system.applicationHost/sites/site[@name='{0}']/logFile/customFields" -f $Site
+        $addHashTable = @{
+            logFieldName = $customField.LogFieldName
+            sourceName = $customField.SourceName
+            sourceType = $customField.SourceType
+        }
+
+        Add-WebConfigurationProperty -Filter $addFilterString -Name "." -Value $addHashTable       
     }
 }
 
@@ -2002,6 +2123,57 @@ function Test-WebsiteBinding
 
 <#
         .SYNOPSIS
+        Helper function used to test the LogCustomField state for a website.
+
+        .PARAMETER Site
+        Specifies the name of the Website.
+
+        .PARAMETER LogCustomField
+        A CimInstance collection of what state the LogCustomField should be.
+#>
+function Test-LogCustomField
+{
+    [CmdletBinding()]
+    [OutputType([Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Site,
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $LogCustomField
+    )
+
+    $inDesiredSate = $true
+
+    foreach ($customField in $LogCustomField)
+    {
+        $filterString = "/system.applicationHost/sites/site[@name='{0}']/logFile/customFields/add[@logFieldName='{1}']" -f $Site, $customField.LogFieldName
+        $presentCustomField = Get-WebConfigurationProperty -Filter $filterString -Name "."
+
+        if ($presentCustomField)
+        {
+            $sourceNameMatch = $customField.SourceName -eq $presentCustomField.sourceName
+            $sourceTypeMatch = $customField.SourceType -eq $presentCustomField.sourceType
+            if(-not ($sourceNameMatch -and $sourceTypeMatch))
+            {
+                $inDesiredSate = $false
+            }
+        }
+        else
+        {
+            $inDesiredSate = $false
+        }      
+    }
+
+    return $inDesiredSate
+}
+
+<#
+        .SYNOPSIS
         Helper function used to update default pages of website.
 #>
 function Update-DefaultPage
@@ -2141,5 +2313,3 @@ function Update-WebsiteBinding
 #endregion
 
 Export-ModuleMember -Function *-TargetResource
-
-

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
@@ -21,6 +21,14 @@ class MSFT_xWebAuthenticationInformation
     [Write] Boolean Windows;
 };
 
+[ClassVersion("1.0.0")]
+class MSFT_xLogCustomFieldInformation
+{
+    [Write] String LogFieldName;
+    [Write] String SourceName;
+    [Write, ValueMap{"RequestHeader","ResponseHeader","ServerVariable"},Values{"RequestHeader","ResponseHeader","ServerVariable"}] String SourceType;
+};
+
 [ClassVersion("2.0.0"), FriendlyName("xWebsite")]
 class MSFT_xWebsite : OMI_BaseResource
 {
@@ -43,4 +51,5 @@ class MSFT_xWebsite : OMI_BaseResource
     [Write, Description ("How large the file should be before it is truncated")] String LogTruncateSize;
     [Write, Description ("Use the localtime for file naming and rollover")] Boolean LoglocalTimeRollover;
     [Write, Description ("Format of the Logfiles. Only W3C supports LogFlags"), ValueMap{"IIS","W3C","NCSA"}, Values{"IIS","W3C","NCSA"}] String LogFormat;
+    [Write, EmbeddedInstance("MSFT_xLogCustomFieldInformation"), Description("Custom log file field information")] String LogCustomFields[];
 };

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
@@ -51,5 +51,5 @@ class MSFT_xWebsite : OMI_BaseResource
     [Write, Description ("How large the file should be before it is truncated")] String LogTruncateSize;
     [Write, Description ("Use the localtime for file naming and rollover")] Boolean LoglocalTimeRollover;
     [Write, Description ("Format of the Logfiles. Only W3C supports LogFlags"), ValueMap{"IIS","W3C","NCSA"}, Values{"IIS","W3C","NCSA"}] String LogFormat;
-    [Write, EmbeddedInstance("MSFT_xLogCustomFieldInformation"), Description("Custom log file field information")] String LogCustomFields[];
+    [Write, EmbeddedInstance("MSFT_xLogCustomFieldInformation"), Description("Custom logging field information")] String LogCustomFields[];
 };

--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **LogTruncateSize**: How large the file should be before it is truncated. If this is set then LogPeriod will be ignored if passed in and set to MaxSize. The value must be a valid integer between `1048576 (1MB)` and `4294967295 (4GB)`.
 * **LoglocalTimeRollover**: Use the localtime for file naming and rollover. The acceptable values for this property are: `$true`, `$false`
 * **LogFormat**: Format of the Logfiles. **Note**Only W3C supports LogFlags. The acceptable values for this property are: `IIS`,`W3C`,`NCSA`
+* **LogCustomFields**: Custom logging field informationin the form of an array of embedded instances of the **MSFT_xLogCustomFieldInformation** CIM class that implements the following properties:
+  * **LogFieldName**: Field name to identify the custom field within the log file. Please note that the field name cannot contain spaces.
+  * **SourceName**: You can select `RequestHeader`, `ResponseHeader`, or `ServerVariable` (note that enhanced logging cannot log a server variable with a name that contains lower-case characters - to include a server variable in the event log just make sure that its name consists of all upper-case characters).
+  * **SourceType**: Name of the HTTP header or server variable (depending on the Source Type you selected) that contains a value that you want to log.
 
 ### xWebApplication
 
@@ -239,6 +243,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased
+* Updated **xWebSite** to include ability to manage custom logging fields
 
 ### 1.19.0.0
 

--- a/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
@@ -123,7 +123,11 @@ try
             #Test DefaultPage is correct
             $defultPages[0] | Should Match $dscConfig.AllNodes.DefaultPage
 
-            }
+            #Test LogCustomFields is correct
+            $result.LogCustomFields.LogFieldName | Should Be $dscConfig.AllNodes.LogFieldName
+            $result.LogCustomFields.SourceName | Should Be $dscConfig.AllNodes.SourceName
+            $result.LogCustomFields.SourceType | Should Be $dscConfig.AllNodes.SourceType
+        }
 
     }
 
@@ -195,7 +199,11 @@ try
             #Test DefaultPage is correct
             $defultPages[0] | Should Match $dscConfig.AllNodes.DefaultPage
 
-            }
+            #Test LogCustomFields is correct
+            $result.LogCustomFields.LogFieldName | Should Be $dscConfig.AllNodes.LogFieldName
+            $result.LogCustomFields.SourceName | Should Be $dscConfig.AllNodes.SourceName
+            $result.LogCustomFields.SourceType | Should Be $dscConfig.AllNodes.SourceType
+        }
 
     }
 

--- a/Tests/Integration/MSFT_xWebsite.config.ps1
+++ b/Tests/Integration/MSFT_xWebsite.config.ps1
@@ -68,6 +68,14 @@ configuration MSFT_xWebsite_Present_Started
             ServiceAutoStartEnabled = $Node.ServiceAutoStartEnabled
             ServiceAutoStartProvider = $Node.ServiceAutoStartProvider
             State = 'Started'
+            LogCustomFields    = @(
+                MSFT_xLogCustomFieldInformation
+                {
+                    LogFieldName = $Node.LogFieldName
+                    SourceName   = $Node.SourceName
+                    SourceType   = $Node.SourceType
+                }
+            )
         }
     }
 }
@@ -141,6 +149,14 @@ configuration MSFT_xWebsite_Present_Stopped
             ServiceAutoStartEnabled = $Node.ServiceAutoStartEnabled
             ServiceAutoStartProvider = $Node.ServiceAutoStartProvider
             State = 'Stopped'
+            LogCustomFields    = @(
+                MSFT_xLogCustomFieldInformation
+                {
+                    LogFieldName = $Node.LogFieldName
+                    SourceName   = $Node.SourceName
+                    SourceType   = $Node.SourceType
+                }
+            )
         }
     }
 }

--- a/Tests/Integration/MSFT_xWebsite.config.psd1
+++ b/Tests/Integration/MSFT_xWebsite.config.psd1
@@ -28,6 +28,9 @@
             HTTPSHostname               = 'https.website'
             CertificateStoreName        = 'MY'
             SslFlags                    = '1'
+            LogFieldName                = 'ClientEncoding'
+            SourceName                  = 'Accept-Encoding'
+            SourceType                  = 'RequestHeader'
         }
     )
 }

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -81,6 +81,12 @@ try
                     -ClientOnly
             )
 
+            $MockLogCustomFields = @{
+                LogFieldName = 'ClientEncoding'
+                SourceName   = 'Accept-Encoding'
+                SourceType   = 'RequestHeader'        
+            }
+
             $MockLogOutput = @{
                 directory         = '%SystemDrive%\inetpub\logs\LogFiles'
                 logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
@@ -88,6 +94,7 @@ try
                 period            = 'Daily'
                 truncateSize      = '1048576'
                 localTimeRollover = 'False'
+                customFields      = @{Collection = @($MockLogCustomFields)}
             }
 
             $MockWebsite = @{
@@ -101,7 +108,7 @@ try
                 LogFile              = $MockLogOutput
                 Count                = 1
             }
-
+            
             Mock -CommandName Assert-Module -MockWith {}
 
             Context 'Website does not exist' {
@@ -258,6 +265,12 @@ try
                 It 'should return LogFormat' {
                     $Result.logFormat | Should Be $MockWebsite.Logfile.logFormat
                 }
+
+                It 'should return LogCustomFields' {
+                    $Result.LogCustomFields.LogFieldName | Should Be $MockLogCustomFields.LogFieldName
+                    $Result.LogCustomFields.SourceName | Should Be $MockLogCustomFields.SourceName
+                    $Result.LogCustomFields.SourceType | Should Be $MockLogCustomFields.SourceType
+                }
             }
         }
 
@@ -274,6 +287,17 @@ try
                     CertificateStoreName  = 'WebHosting'
                     SslFlags              = 1
                 } -ClientOnly
+            )
+
+            $MockCimLogCustomFields = @(
+                New-CimInstance -ClassName MSFT_xLogCustomFieldInformation `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                    } `
+                    -ClientOnly
             )
 
             $MockParameters = @{
@@ -294,6 +318,7 @@ try
                 LogPeriod                = 'Hourly'
                 LogTruncateSize          = '2000000'
                 LoglocalTimeRollover     = $True
+                LogCustomFields          = $MockCimLogCustomFields
             }
 
             $MockWebBinding = @(
@@ -314,6 +339,12 @@ try
                 }
             )
 
+            $MockLogCustomFields = @{
+                LogFieldName = 'ClientEncoding'
+                SourceName   = 'Accept-Encoding'
+                SourceType   = 'RequestHeader'        
+            }
+
             $MockLogOutput = @{
                 directory         = '%SystemDrive%\inetpub\logs\LogFiles'
                 logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
@@ -321,6 +352,7 @@ try
                 period            = 'Daily'
                 truncateSize      = '1048576'
                 localTimeRollover = 'False'
+                customFields      = @{Collection = @($MockLogCustomFields)}
             }
 
             $MockWebsite = @{
@@ -737,6 +769,42 @@ try
                     $result | Should be $false
                 }
             }
+
+            Context 'Check LogCustomFields is equal' {
+                Mock -CommandName Get-Website -MockWith {return $MockWebsite}
+
+                Mock -CommandName Get-WebConfigurationProperty `
+                    -MockWith {return $MockLogCustomFields }
+
+                $Result = Test-TargetResource -Ensure $MockParameters.Ensure `
+                    -Name $MockParameters.Name `
+                    -LogCustomFields $MockParameters.LogCustomFields
+
+                It 'Should return true' {
+                    $result | Should be $true
+                }                
+            }
+
+            Context 'Check LogCustomFields is different' {
+                Mock -CommandName Get-Website -MockWith {return $MockWebsite}
+
+                $MockDifferentLogCustomFields = @{
+                    LogFieldName = 'DifferentField'
+                    SourceName   = 'Accept-Encoding'
+                    SourceType   = 'DifferentSourceType'                                
+                }
+
+                Mock -CommandName Get-WebConfigurationProperty `
+                    -MockWith {return $MockDifferentLogCustomFields }
+
+                $Result = Test-TargetResource -Ensure $MockParameters.Ensure `
+                    -Name $MockParameters.Name `
+                    -LogCustomFields $MockParameters.LogCustomFields
+
+                It 'Should return false' {
+                    $result | Should be $false
+                }                
+            }
         }
 
         Describe "how $script:DSCResourceName\Set-TargetResource responds to Ensure = 'Present'" {
@@ -759,6 +827,17 @@ try
                     } -ClientOnly
             )
 
+            $MockCimLogCustomFields = @(
+                New-CimInstance -ClassName MSFT_xLogCustomFieldInformation `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                    } `
+                    -ClientOnly
+            )
+
             $MockParameters = @{
                 Ensure                   = 'Present'
                 Name                     = 'MockName'
@@ -779,6 +858,7 @@ try
                 LogTruncateSize          = '2000000'
                 LoglocalTimeRollover     = $True
                 LogFormat                = 'W3C'
+                LogCustomFields          = $MockCimLogCustomFields
             }
 
             $MockWebBinding = @(
@@ -799,6 +879,12 @@ try
                 }
             )
 
+            $MockLogCustomFields = @{
+                LogFieldName = 'ClientEncoding'
+                SourceName   = 'Accept-Encoding'
+                SourceType   = 'RequestHeader'        
+            }
+
             $MockLogOutput =
                 @{
                     directory         = '%SystemDrive%\inetpub\logs\LogFiles'
@@ -807,6 +893,7 @@ try
                     period            = 'Daily'
                     truncateSize      = '1048576'
                     localTimeRollover = 'False'
+                    customFields      = @{Collection = @($MockLogCustomFields)}
                 }
 
             $MockWebsite = @{
@@ -865,6 +952,12 @@ try
                 Mock -CommandName Test-AuthenticationEnabled { return $false } `
                     -ParameterFilter { ($Type -eq 'Windows') }
 
+                Mock -CommandName Add-WebConfigurationProperty
+
+                Mock -CommandName Get-WebConfigurationProperty
+
+                Mock -CommandName Test-LogCustomField -MockWith { return $false }
+
                 Set-TargetResource @MockParameters
 
                 It 'Should call all the mocks' {
@@ -880,9 +973,11 @@ try
                     Assert-MockCalled -CommandName Set-Item -Exactly 3
                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly 9
                     Assert-MockCalled -CommandName Start-Website -Exactly 1
+                    Assert-MockCalled -CommandName Add-WebConfigurationProperty -Exactly 1
+                    Assert-MockCalled -CommandName Get-WebConfigurationProperty -Exactly 1
+                    Assert-MockCalled -CommandName Test-LogCustomField -Exactly 1
                 }
             }
-
             
             Context 'Create website with empty physical path' {
                 
@@ -3422,6 +3517,127 @@ try
                     { Update-WebsiteBinding `
                         -Name $MockWebsite.Name `
                         -BindingInfo $MockBindingInfo } | Should Throw $ErrorRecord
+                }
+            }
+        }
+
+        Describe "$script:DSCResourceName\ConvertTo-CimLogCustomFields"{
+            $MockLogCustomFields = @{
+                LogFieldName = 'ClientEncoding'
+                SourceName   = 'Accept-Encoding'
+                SourceType   = 'RequestHeader'        
+            }
+
+            Context 'Expected behavior'{
+                $Result = ConvertTo-CimLogCustomFields -InputObject $MockLogCustomFields
+
+                It 'should return the LogFieldName' {
+                    $Result.LogFieldName | Should Be $MockLogCustomFields.LogFieldName
+                }
+
+                It 'should return the SourceName' {
+                    $Result.SourceName | Should Be $MockLogCustomFields.SourceName
+                }
+
+                It 'should return the LogFieldName' {
+                    $Result.SourceType | Should Be $MockLogCustomFields.SourceType
+                }
+            }
+        }
+
+        Describe "$script:DSCResourceName\Test-LogCustomField"{
+            $MockWebsiteName = 'ContosoSite'
+            
+            $MockCimLogCustomFields = @(
+                New-CimInstance -ClassName MSFT_xLogCustomFieldInformation `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                    } `
+                    -ClientOnly
+            )
+
+            Context 'LogCustomField in desired state'{
+                $MockDesiredLogCustomFields = @{
+                    LogFieldName = 'ClientEncoding'
+                    SourceName   = 'Accept-Encoding'
+                    SourceType   = 'RequestHeader'        
+                }
+                
+                Mock -CommandName Get-WebConfigurationProperty -MockWith { return $MockDesiredLogCustomFields }
+
+               It 'should return True' {
+                    Test-LogCustomField -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFields | Should Be $True
+                }
+            }
+
+            Context 'LogCustomField not in desired state'{
+                $MockWrongLogCustomFields = @{
+                    LogFieldName = 'ClientEncoding'
+                    SourceName   = 'WrongSourceName'
+                    SourceType   = 'WrongSourceType'        
+                }
+                
+                Mock -CommandName Get-WebConfigurationProperty -MockWith { return $MockWrongLogCustomFields }
+
+                It 'should return False' {
+                    Test-LogCustomField -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFields | Should Be $False
+                }
+            }
+
+            Context 'LogCustomField not present'{               
+                Mock -CommandName Get-WebConfigurationProperty -MockWith { return $false }
+
+                It 'should return False' {
+                    Test-LogCustomField -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFields | Should Be $False
+                }
+            }
+
+        }
+
+        Describe "$script:DSCResourceName\Set-LogCustomField"{
+            $MockWebsiteName = 'ContosoSite'
+            
+            $MockCimLogCustomFields = @(
+                New-CimInstance -ClassName MSFT_xLogCustomFieldInformation `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                    } `
+                    -ClientOnly
+            )
+
+            Context 'Create new LogCustomField'{
+                Mock -CommandName Get-WebConfigurationProperty -MockWith { return $false }
+                Mock -CommandName Add-WebConfigurationProperty
+
+                It 'should not throw an error' {
+                    { Set-LogCustomField  -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFields } | Should Not Throw
+                }
+
+                It 'should call should call expected mocks' {
+                    Assert-MockCalled -CommandName Get-WebConfigurationProperty -Exactly 1
+                    Assert-MockCalled -CommandName Add-WebConfigurationProperty -Exactly 1
+                }
+            }
+
+            Context 'Modify existing LogCustomField'{
+                Mock -CommandName Get-WebConfigurationProperty -MockWith { return $true }
+                Mock -CommandName Add-WebConfigurationProperty
+                Mock -CommandName Clear-WebConfiguration
+
+                It 'should not throw an error' {
+                    { Set-LogCustomField  -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFields } | Should Not Throw
+                }
+
+                It 'should call should call expected mocks' {
+                    Assert-MockCalled -CommandName Get-WebConfigurationProperty -Exactly 1
+                    Assert-MockCalled -CommandName Add-WebConfigurationProperty -Exactly 1
+                    Assert-MockCalled -CommandName Clear-WebConfiguration -Exactly 1
                 }
             }
         }


### PR DESCRIPTION
Modified xWebSite to include the ability to manage logging custom fields.

Below is an example of how to add a logging custom field with the updated resource:

```
xWebsite NewWebsite
{
    Ensure             = 'Present'
    Name               = 'Default Web Site'
    LogCustomFields    = MSFT_xLogCustomFieldInformation
    {
        LogFieldName   = 'Original-IP'
        SourceName     = 'X-Forwarded-For'
        SourceType     = 'RequestHeader'
    }
}
```