### PR TITLE
Fix Issue #302 - MSFT_xWebsite.psm1

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -1663,9 +1663,10 @@ function Get-AuthenticationInfo
                                                                                -Type $type)
     }
 
-    return New-CimInstance `
+    $authenticationStatus = New-CimInstance `
             -ClassName MSFT_xWebAuthenticationInformation `
-            -ClientOnly -Property $authenticationProperties
+            -ClientOnly -Property $authenticationProperties 
+    return $authenticationStatus | Select-Object -Property Anonymous,Basic,Digest,Windows
 }
 
 <#


### PR DESCRIPTION
Changed return value for Get-AuthenticationInfo function to return only expected values to prevent: 
Get-DscConfiguration : A general error occurred that is not covered by a more specific error code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/341)
<!-- Reviewable:end -->
