### PR TITLE
BREAKING CHANGE: Update xIisFeatureDelegation to manage all sections

### DIFF
--- a/DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.psm1
+++ b/DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.psm1
@@ -30,6 +30,7 @@ data LocalizedData
 #>
 function Get-TargetResource
 {
+    [CmdletBinding()]
     [OutputType([Hashtable])]
     param
     (
@@ -57,7 +58,7 @@ function Get-TargetResource
     return @{
         Path         = $Path
         Filter       = $Filter
-        OverrideMode = $OverrideMode
+        OverrideMode = $currentOverrideMode
     }
 }
 
@@ -77,6 +78,7 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -118,6 +120,7 @@ function Set-TargetResource
 #>
 function Test-TargetResource
 {
+    [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
     (
@@ -163,6 +166,7 @@ function Test-TargetResource
 #>
 function Get-OverrideMode
 {
+    [CmdletBinding()]
     [OutputType([System.String])]
     param
     (

--- a/DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.psm1
+++ b/DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.psm1
@@ -77,7 +77,6 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -97,9 +96,9 @@ function Set-TargetResource
         $Path
     )
 
-     Write-Verbose -Message ( $($LocalizedData.VerboseSetTargetResource) -f $Filter, $OverrideMode )
+     Write-Verbose -Message ( $LocalizedData.VerboseSetTargetResource -f $Filter, $OverrideMode )
 
-     Set-WebConfiguration -Filter $Filter -PsPath $PsPath -Metadata 'overrideMode' -Value $OverrideMode
+     Set-WebConfiguration -Filter $Filter -PsPath $Path -Metadata 'overrideMode' -Value $OverrideMode
 }
 
 <#
@@ -119,7 +118,6 @@ function Set-TargetResource
 #>
 function Test-TargetResource
 {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [OutputType([System.Boolean])]
     param
     (
@@ -158,7 +156,7 @@ function Test-TargetResource
     .PARAMETER Filter
         Specifies the IIS configuration section.
 
-    .PARAMETER PsPath
+    .PARAMETER Path
         Specifies the configuration path. This can be either an IIS configuration path in the format
         computer machine/webroot/apphost, or the IIS module path in this format IIS:\sites\Default Web Site.
 
@@ -181,7 +179,7 @@ function Get-OverrideMode
 
     Assert-Module
 
-    Write-Verbose -Message ( $($LocalizedData.ChangedMessage) -f $Filter )
+    Write-Verbose -Message ( $LocalizedData.GetOverrideMode -f $Filter )
 
     $webConfig = Get-WebConfiguration -PsPath $Path -Filter $Filter -Metadata
 

--- a/DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.psm1
+++ b/DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.psm1
@@ -197,8 +197,6 @@ function Get-OverrideMode
 
     return $currentOverrideMode
 }
-
-
 #endregion
 
 Export-ModuleMember -function *-TargetResource

--- a/DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.schema.mof
+++ b/DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.schema.mof
@@ -1,6 +1,7 @@
-[ClassVersion("1.0.0"), FriendlyName("xIisFeatureDelegation")] 
+[ClassVersion("1.0.0"), FriendlyName("xIisFeatureDelegation")]
 class MSFT_xIisFeatureDelegation : OMI_BaseResource
 {
-  [Key] string SectionName;
-  [Key,ValueMap{"Allow", "Deny"},Values{"Allow", "Deny"}] string OverrideMode;
+  [Key, Description("Specifies the configuration path. This can be either an IIS configuration path in the format computer machine/webroot/apphost, or the IIS module path in this format IIS:\\sites\\Default Web Site.")] String Path;
+  [Key, Description("Specifies the IIS configuration section to lock or unlock.")] String Filter;
+  [Required, Description("Determines whether to lock or unlock the specified section."), ValueMap{"Allow", "Deny"}, Values{"Allow", "Deny"}] string OverrideMode;
 };

--- a/Examples/Sample_xIisFeatureDelegation_AllowSome.ps1
+++ b/Examples/Sample_xIisFeatureDelegation_AllowSome.ps1
@@ -1,4 +1,9 @@
-configuration Sample_IISFeatureDelegation
+<#
+    .SYNOPSIS
+        This example will install the IIS Windows Feature and unlocks the IIS configuration
+        sections specified by the Filter setting.
+#>
+configuration Example
 {
     param
     (
@@ -7,9 +12,8 @@ configuration Sample_IISFeatureDelegation
         $NodeName = 'localhost'
     )
 
-    # Import the module that defines custom resources
     Import-DscResource -Module xWebAdministration
-    Import-DscResource -Module PSDesiredStateConfiguration
+    Import-DscResource -Module PSDscResources
 
     Node $NodeName
     {

--- a/Examples/Sample_xIisFeatureDelegation_AllowSome.ps1
+++ b/Examples/Sample_xIisFeatureDelegation_AllowSome.ps1
@@ -2,12 +2,14 @@ configuration Sample_IISFeatureDelegation
 {
     param
     (
-        # Target nodes to apply the configuration
-        [string[]] $NodeName = 'localhost'
+        [Parameter()]
+        [string[]]
+        $NodeName = 'localhost'
     )
 
     # Import the module that defines custom resources
-    Import-DscResource -Module xWebAdministration, PSDesiredStateConfiguration
+    Import-DscResource -Module xWebAdministration
+    Import-DscResource -Module PSDesiredStateConfiguration
 
     Node $NodeName
     {
@@ -21,19 +23,23 @@ configuration Sample_IISFeatureDelegation
         # Allow Write access to some section that normally don't have it.
         xIisFeatureDelegation serverRuntime
         {
-            SectionName  = 'serverRuntime'
+            Filter       = '/system.webserver/serverRuntime'
             OverrideMode = 'Allow'
-        }
-        xIisFeatureDelegation anonymousAuthentication
-        {
-            SectionName  = 'security/authentication/anonymousAuthentication'
-            OverrideMode = 'Allow'
+            Path         = 'MACHINE/WEBROOT/APPHOST'
         }
 
-        xIisFeatureDelegation ipSecurity
+        xIisFeatureDelegation anonymousAuthentication
         {
-            SectionName  = 'security/ipSecurity'
+            Filter       = '/system.webserver/security/authentication/anonymousAuthentication'
             OverrideMode = 'Allow'
+            Path         = 'MACHINE/WEBROOT/APPHOST'
+        }
+
+        xIisFeatureDelegation sessionState
+        {
+            Filter       = '/system.web/sessionState'
+            OverrideMode = 'Allow'
+            Path         = 'MACHINE/WEBROOT/APPHOST'
         }
     }
 }

--- a/Examples/Sample_xIisFeatureDelegation_IisConfigurationPathFormat.ps1
+++ b/Examples/Sample_xIisFeatureDelegation_IisConfigurationPathFormat.ps1
@@ -1,7 +1,8 @@
 <#
     .SYNOPSIS
         This example will install the IIS Windows Feature and unlocks the IIS configuration
-        sections specified by the Filter setting.
+        sections specified by the Filter setting. This example uses the IIS Configuration Path format
+        for the 'Path' setting.
 #>
 configuration Example
 {

--- a/Examples/Sample_xIisFeatureDelegation_IisModulePathFormat.ps1
+++ b/Examples/Sample_xIisFeatureDelegation_IisModulePathFormat.ps1
@@ -1,0 +1,50 @@
+<#
+    .SYNOPSIS
+        This example will install the IIS Windows Feature and unlocks the IIS configuration
+        sections specified by the Filter setting.  This example uses the IIS Module Path format
+        for the 'Path' setting.
+#>
+configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [string[]]
+        $NodeName = 'localhost'
+    )
+
+    Import-DscResource -Module xWebAdministration
+    Import-DscResource -Module PSDscResources
+
+    Node $NodeName
+    {
+        # Install the IIS role
+        WindowsFeature IIS
+        {
+            Ensure = 'Present'
+            Name   = 'Web-Server'
+        }
+
+        # Allow Write access to some section that normally don't have it.
+        xIisFeatureDelegation serverRuntime
+        {
+            Filter       = '/system.webserver/serverRuntime'
+            OverrideMode = 'Allow'
+            Path         = 'IIS:\Sites\Default Web Site'
+        }
+
+        xIisFeatureDelegation anonymousAuthentication
+        {
+            Filter       = '/system.webserver/security/authentication/anonymousAuthentication'
+            OverrideMode = 'Allow'
+            Path         = 'IIS:\Sites\Default Web Site'
+        }
+
+        xIisFeatureDelegation sessionState
+        {
+            Filter       = '/system.web/sessionState'
+            OverrideMode = 'Allow'
+            Path         = 'IIS:\Sites\Default Web Site'
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### xIisFeatureDelegation
 
-* **SectionName**: Relative path of the section to delegate such as **security/authentication**
+* **Filter**: Specifies the IIS configuration section to lock or unlock in this format: **/system.webserver/security/authentication/anonymousAuthentication**
+* **Path**: Specifies the configuration path. This can be either an IIS configuration path in the format computer machine/webroot/apphost, or the IIS module path in this format IIS:\sites\Default Web Site.
 * **OverrideMode**: Mode of that section { **Allow** | **Deny** }
 
 ### xIisMimeTypeMapping
@@ -273,6 +274,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * Updated **xIISLogging** to include ability to manage custom logging fields
   ([issue #267](https://github.com/PowerShell/xWebAdministration/issues/267)).
   [@ldillonel](https://github.com/ldillonel)
+* Updated **xWebSite** to include ability to manage custom logging fields
+* Breaking Change: Updated **xIisFeatureDelegation** to be able to manage any configuration section
 
 ### 1.20.0.0
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### xIisFeatureDelegation
 
+This resource manages the IIS configuration section locking (overrideMode) to control what configuration can be set in web.config.
+
 * **Filter**: Specifies the IIS configuration section to lock or unlock in this format: **/system.webserver/security/authentication/anonymousAuthentication**
 * **Path**: Specifies the configuration path. This can be either an IIS configuration path in the format computer machine/webroot/apphost, or the IIS module path in this format IIS:\sites\Default Web Site.
 * **OverrideMode**: Mode of that section { **Allow** | **Deny** }
@@ -275,7 +277,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   ([issue #267](https://github.com/PowerShell/xWebAdministration/issues/267)).
   [@ldillonel](https://github.com/ldillonel)
 * Updated **xWebSite** to include ability to manage custom logging fields
-* Breaking Change: Updated **xIisFeatureDelegation** to be able to manage any configuration section
+* BREAKING CHANGE: Updated **xIisFeatureDelegation** to be able to manage any configuration section
 
 ### 1.20.0.0
 

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 This resource manages the IIS configuration section locking (overrideMode) to control what configuration can be set in web.config.
 
 * **Filter**: Specifies the IIS configuration section to lock or unlock in this format: **/system.webserver/security/authentication/anonymousAuthentication**
-* **Path**: Specifies the configuration path. This can be either an IIS configuration path in the format computer machine/webroot/apphost, or the IIS module path in this format IIS:\sites\Default Web Site.
 * **OverrideMode**: Mode of that section { **Allow** | **Deny** }
+* **Path**: Specifies the configuration path. This can be either an IIS configuration path in the format computer machine/webroot/apphost, or the IIS module path in this format IIS:\sites\Default Web Site. *WARNING: both path types can be used to manage the same feature delegation, however, there is no way to control if two resources in the configuration set the same feature delegation*.
 
 ### xIisMimeTypeMapping
 

--- a/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
@@ -1,22 +1,20 @@
-
 $script:DSCModuleName = 'xWebAdministration'
 $script:DSCResourceName = 'MSFT_xIISFeatureDelegation'
 
 #region HEADER
-
-# Integration Test Template Version: 1.1.0
-$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+# Integration Test Template Version: 1.2.1
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
 }
 
-Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `
-    -TestType Integration 
+    -TestType Integration
 
 #endregion
 
@@ -24,85 +22,93 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 try
 {
-    # Now that xWebAdministration should be discoverable load the configuration data
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
-    . $ConfigFile
+    #region Integration Tests
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    . $configFile
 
     $null = Backup-WebConfiguration -Name $tempName
 
     Describe "$($script:DSCResourceName)_Integration" {
-        # Allow Feature Delegation
-        # for this test we are using the anonymous Authentication feature, which is installed by default, but has Feature Delegation set to denied by default
-        if ((Get-WindowsOptionalFeature –Online | Where-Object {$_.FeatureName -eq 'IIS-Security' -and $_.State -eq 'Enabled'}).Count -eq 1)
-        {
-            if ((Get-WebConfiguration /system.webserver/security/authentication/anonymousAuthentication iis:\).OverrideModeEffective -eq 'Deny')
-            {
-                It 'Allow Feature Delegation'{
-                    {
-                        &($script:DSCResourceName + '_AllowDelegation') -OutputPath $TestDrive
-                        Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-                    } | Should not throw
+        $startDscConfigurationParameters = @{
+            Path         = $TestDrive
+            ComputerName = 'localhost'
+            Wait         = $true
+            Verbose      = $true
+            Force        = $true
+            ErrorAction  = 'Stop'
+        }
 
-                    (Get-WebConfiguration /system.webserver/security/authentication/anonymousAuthentication iis:\).OverrideModeEffective  | Should be 'Allow'
-                }
+        Context 'Allow Feature Delegation'{
+            $currentOverrideMode = (Get-WebConfiguration -Filter '/system.web/customErrors' -Pspath iis:\ -Metadata).Metadata.effectiveOverrideMode
+            #For this test we want the target section to start at effectiveOverrideMode 'Deny'
+            If ( $currentOverrideMode -ne 'Deny')
+            {
+                Set-WebConfiguration -Filter '/system.web/customErrors' -PsPath 'MACHINE/WEBROOT/APPHOST' -Metadata 'overrideMode' -Value 'Deny'
+            }
+
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:DSCResourceName)_AllowDelegation" -OutputPath $TestDrive
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should Not Throw
+            }
+
+            It 'Should be set to Allow Feature Delegation'{
+                (Get-WebConfiguration -Filter '/system.web/customErrors' -Pspath 'MACHINE/WEBROOT/APPHOST' -Metadata).Metadata.effectiveOverrideMode | Should be 'Allow'
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            }
+
+            It 'Should return $True for Test-DscConfiguration' {
+                Test-DscConfiguration | Should be $True
             }
         }
-        #
-        # These test are broken and will be fixed under a future PR at https://github.com/PowerShell/xWebAdministration
-        #
-        # It 'Deny Feature Delegation' {
-        #     {
-        #         # this test doesn't really test the resource if it defaultDocument
-        #         # is already Deny (not the default)
-        #         # well it doesn't test the Set Method, but does test the Test method
-        #         # What if the default document module is not installed?
 
-        #         Invoke-Expression -Command "$($script:DSCResourceName)_DenyDelegation -OutputPath `$TestDrive"
-        #         Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
+        Context 'Deny Feature Delegation'{
+            $currentOverrideMode = (Get-WebConfiguration -Filter 'system.webServer/defaultDocument' -Pspath 'MACHINE/WEBROOT/APPHOST' -Metadata).Metadata.effectiveOverrideMode
+            #For this test we want the target section to start at effectiveOverrideMode 'Allow'
+            If ( $currentOverrideMode -ne 'Allow')
+            {
+                Set-WebConfiguration -Filter 'system.webServer/defaultDocument' -PsPath 'MACHINE/WEBROOT/APPHOST' -Metadata 'overrideMode' -Value 'Allow'
+            }
 
-        #         # Now lets try to add a new default document on site level, this should fail
-        #         # get the first site, it doesn't matter which one, it should fail.
-        #         $siteName = (Get-ChildItem iis:\sites | Select -First 1).Name
-        #         Add-WebConfigurationProperty `
-        #             -PSPath "MACHINE/WEBROOT/APPHOST/$siteName" `
-        #             -Filter 'system.webServer/defaultDocument/files' `
-        #             -Name '.' `
-        #             -Value @{Value = 'pesterpage.cgi'}
+            $siteName = (Get-ChildItem -Path iis:\sites | Select-Object -First 1).Name
+            $testValue = @{Value = 'pesterpage.cgi'}
+            $testAddWebConfigurationProperty = @{
+                PSPath = "MACHINE/WEBROOT/APPHOST/$siteName"
+                Filter = 'system.webServer/defaultDocument/files'
+                Name = '.'
+            }
+            $testRemoveWebConfigurationProperty = $testAddWebConfigurationProperty.Clone()
+            $testRemoveWebConfigurationProperty.Add('AtElement', $testValue)
+            $testAddWebConfigurationProperty.Add('Value', $testValue)
 
-        #         # remove it again, should also fail, but if both work we at least cleaned it up,
-        #         # it would be better to backup and restore the web.config file.
-        #         Remove-WebConfigurationProperty  `
-        #             -PSPath "MACHINE/WEBROOT/APPHOST/$siteName" `
-        #             -Filter 'system.webServer/defaultDocument/files' `
-        #             -Name '.' `
-        #             -AtElement @{Value = 'pesterpage.cgi'}
-        #     } | Should Not Throw
-        # }
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:DSCResourceName)_DenyDelegation" -OutputPath $TestDrive
 
-        #It 'Deny Feature Delegation' -test {
-        #{
-        #    # this test doesn't really test the resource if it defaultDocument
-        #    # is already Deny (not the default)
-        #    # well it doesn't test the Set Method, but does test the Test method
-        #    # What if the default document module is not installed?
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should Not Throw
+            }
 
-        #    Invoke-Expression -Command "$($script:DSCResourceName)_DenyDelegation -OutputPath `$TestDrive"
-        #    Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            }
 
-        #    # Now lets try to add a new default document on site level, this should fail
-        #    # get the first site, it doesn't matter which one, it should fail.
-        #    $siteName = (Get-ChildItem iis:\sites | Select-Object -First 1).Name
-        #    Add-WebConfigurationProperty -pspath "MACHINE/WEBROOT/APPHOST/$siteName"  -filter 'system.webServer/defaultDocument/files' -name '.' -value @{value='pesterpage.cgi'}
+            It 'Should return $True for Test-DscConfiguration' {
+                Test-DscConfiguration | Should be $True
+            }
 
-        #    # remove it again, should also fail, but if both work we at least cleaned it up, it would be better to backup and restore the web.config file.
-        #    Remove-WebConfigurationProperty  -pspath "MACHINE/WEBROOT/APPHOST/$siteName"  -filter 'system.webServer/defaultDocument/files' -name '.' -AtElement @{value='pesterpage.cgi'} } | should throw
-        #}
+            It 'Should Deny Feature Delegation' {
+                { Add-WebConfigurationProperty @testAddWebConfigurationProperty } | Should Throw
 
-        #region DEFAULT TESTS
-          It 'should be able to call Get-DscConfiguration without throwing' {
-              { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
-          }
-        #endregion
+                { Remove-WebConfigurationProperty @testRemoveWebConfigurationProperty } | Should Throw
+            }
+        }
+    #endregion
     }
 }
 finally

--- a/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
@@ -56,7 +56,7 @@ try
             }
 
             It 'Should be set to Allow Feature Delegation'{
-                (Get-WebConfiguration -Filter '/system.web/customErrors' -Pspath 'MACHINE/WEBROOT/APPHOST' -Metadata).Metadata.effectiveOverrideMode | Should be 'Allow'
+                (Get-WebConfiguration -Filter '/system.web/customErrors' -Pspath 'MACHINE/WEBROOT/APPHOST' -Metadata).Metadata.effectiveOverrideMode | Should Be 'Allow'
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
@@ -64,7 +64,7 @@ try
             }
 
             It 'Should return $true for Test-DscConfiguration' {
-                Test-DscConfiguration | Should be $true
+                Test-DscConfiguration | Should Be $true
             }
 
             It 'Should have set the resource and all the parameters should match' {
@@ -110,7 +110,7 @@ try
             }
 
             It 'Should return $true for Test-DscConfiguration' {
-                Test-DscConfiguration | Should be $true
+                Test-DscConfiguration | Should Be $true
             }
 
             It 'Should Deny Feature Delegation' {

--- a/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
@@ -104,8 +104,6 @@ try
 
             It 'Should Deny Feature Delegation' {
                 { Add-WebConfigurationProperty @testAddWebConfigurationProperty } | Should Throw
-
-                { Remove-WebConfigurationProperty @testRemoveWebConfigurationProperty } | Should Throw
             }
         }
     #endregion

--- a/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIISFeatureDelegation.Integration.Tests.ps1
@@ -76,15 +76,12 @@ try
             }
 
             $siteName = (Get-ChildItem -Path iis:\sites | Select-Object -First 1).Name
-            $testValue = @{Value = 'pesterpage.cgi'}
             $testAddWebConfigurationProperty = @{
                 PSPath = "MACHINE/WEBROOT/APPHOST/$siteName"
                 Filter = 'system.webServer/defaultDocument/files'
-                Name = '.'
+                Name   = '.'
+                Value  = 'pesterpage.cgi'
             }
-            $testRemoveWebConfigurationProperty = $testAddWebConfigurationProperty.Clone()
-            $testRemoveWebConfigurationProperty.Add('AtElement', $testValue)
-            $testAddWebConfigurationProperty.Add('Value', $testValue)
 
             It 'Should compile and apply the MOF without throwing' {
                 {

--- a/Tests/Integration/MSFT_xIISFeatureDelegation.config.ps1
+++ b/Tests/Integration/MSFT_xIISFeatureDelegation.config.ps1
@@ -4,7 +4,8 @@ configuration MSFT_xIISFeatureDelegation_AllowDelegation
 
     xIisFeatureDelegation AllowDelegation
     {
-        SectionName = 'security/authentication/anonymousAuthentication'
+        Path = 'MACHINE/WEBROOT/APPHOST'
+        Filter = '/system.web/customErrors'
         OverrideMode = 'Allow'
     }
 }
@@ -15,7 +16,8 @@ configuration MSFT_xIISFeatureDelegation_DenyDelegation
 
     xIisFeatureDelegation DenyDelegation
     {
-        SectionName = 'defaultDocument'
+        Path = 'MACHINE/WEBROOT/APPHOST'
+        Filter = '/system.webServer/defaultDocument'
         OverrideMode = 'Deny'
     }
 }

--- a/Tests/Unit/MSFT_xIISFeatureDelegation.Tests.ps1
+++ b/Tests/Unit/MSFT_xIISFeatureDelegation.Tests.ps1
@@ -51,8 +51,8 @@ try
 
         #region Function Get-TargetResource
         Describe 'MSFT_xIISFeatureDelegation\Get-TargetResource' {
-            Context 'OverrideMode is set to Allow' {
-                Mock Get-WebConfiguration {return $mockAllowOverrideMode}
+            Context 'When OverrideMode is set to Allow' {
+                Mock -CommandName Get-WebConfiguration -MockWith { return $mockAllowOverrideMode }
                 $result = Get-TargetResource @allowTargetResourceParameters
 
                 It 'Should return the correct properties' {
@@ -61,8 +61,8 @@ try
                     $result.OverrideMode | Should Be $allowTargetResourceParameters.OverrideMode
                 }
             }
-            Context 'OverRideMode is set to Deny' {
-                Mock Get-WebConfiguration {return $mockDenyOverrideMode}
+            Context 'When OverrideMode is set to Deny' {
+                Mock -CommandName Get-WebConfiguration -MockWith { return $mockDenyOverrideMode }
                 $result = Get-TargetResource @denytargetResourceParameters
 
                 It 'Should return the correct properties' {
@@ -76,28 +76,28 @@ try
 
         #region Function Test-TargetResource
         Describe 'MSFT_xIISFeatureDelegation\Test-TargetResource' {
-            Context 'OverrideMode is set to Allow' {
-                Mock Get-WebConfiguration {return $mockAllowOverrideMode}
+            Context 'When OverrideMode is set to Allow' {
+                Mock -CommandName Get-WebConfiguration -MockWith { return $mockAllowOverrideMode }
                 It 'Should return True when in desired state' {
                     $results = Test-TargetResource @allowTargetResourceParameters
                     $results | Should Be $true
                 }
 
-                Mock Get-WebConfiguration {return $mockDenyOverrideMode}
+                Mock -CommandName Get-WebConfiguration -MockWith { return $mockDenyOverrideMode }
                 It 'Should return False when not in desired state' {
                     $results = Test-TargetResource @allowTargetResourceParameters
                     $results | Should Be $false
                 }
             }
 
-            Context 'OverideMode is set to Deny' {
-                Mock Get-WebConfiguration {return $mockDenyOverrideMode}
+            Context 'When OverrideMode is set to Deny' {
+                Mock -CommandName Get-WebConfiguration -MockWith { return $mockDenyOverrideMode }
                 It 'Should return True when in desired state' {
                     $results = Test-TargetResource @denyTargetResourceParameters
                     $results | Should Be $true
                 }
 
-                Mock Get-WebConfiguration {return $mockAllowOverrideMode}
+                Mock -CommandName Get-WebConfiguration -MockWith { return $mockAllowOverrideMode }
                 It 'Should return False when not in desired state' {
                     $results = Test-TargetResource @denyTargetResourceParameters
                     $results | Should Be $false
@@ -108,14 +108,14 @@ try
 
         #region Function Set-TargetResource
         Describe 'MSFT_xIISFeatureDelegation\Set-TargetResource' {
-            Context 'Resource not in desired state' {
+            Context 'When resource not in desired state' {
 
-                Mock Set-WebConfiguration
+                Mock -CommandName Set-WebConfiguration -ParameterFilter { $Filter -eq $allowTargetResourceParameters.Filter -and $PsPath -eq $allowTargetResourceParameters.Path }
 
                 Set-TargetResource @allowTargetResourceParameters
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled Set-WebConfiguration -Exactly 1
+                    Assert-MockCalled Set-WebConfiguration -Exactly -Times 1
                 }
             }
         }
@@ -133,29 +133,37 @@ try
 
             Mock -CommandName Assert-Module -MockWith {}
 
-            Context 'OverrideMode is invalid' {
+            Context 'When OverrideMode is invalid' {
                 It 'Should throw an error on null' {
-                    Mock Get-WebConfiguration { return $mockWebConfigOutput }
+                    Mock -CommandName Get-WebConfiguration  -MockWith { return $mockWebConfigOutput }
 
                     {Get-OverrideMode @getOverrideModeParameters} | Should Throw ($LocalizedData.UnableToGetConfig -f $getOverrideModeParameters.Filter)
                 }
 
                 It 'Should throw an error on the wrong value' {
                     $mockWebConfigOutput.Metadata.effectiveOverrideMode = 'Wrong'
-                    Mock Get-WebConfiguration { return $mockWebConfigOutput }
+                    Mock -CommandName Get-WebConfiguration  -MockWith { return $mockWebConfigOutput }
 
                     {Get-OverrideMode @getOverrideModeParameters} | Should Throw ($LocalizedData.UnableToGetConfig -f $getOverrideModeParameters.Filter)
                 }
             }
 
-            Context 'OverrideMode is valid' {
-                Mock -CommandName Get-WebConfiguration -MockWith {return $mockAllowOverrideMode}
+            Context 'When OverrideMode is Allow' {
+                Mock -CommandName Get-WebConfiguration -MockWith { return $mockAllowOverrideMode }
 
                 $overrideMode = Get-OverrideMode @getOverrideModeParameters
                 It 'Should be Allow' {
                     $overrideMode | Should Be 'Allow'
                 }
+            }
 
+            Context 'When OverrideMode is Deny' {
+                Mock -CommandName Get-WebConfiguration -MockWith { return $mockDenyOverrideMode }
+
+                $overrideMode = Get-OverrideMode @getOverrideModeParameters
+                It 'Should be Deny' {
+                    $overrideMode | Should Be 'Deny'
+                }
             }
         }
     }

--- a/Tests/Unit/MSFT_xIISFeatureDelegation.Tests.ps1
+++ b/Tests/Unit/MSFT_xIISFeatureDelegation.Tests.ps1
@@ -31,6 +31,7 @@ try
                 effectiveOverrideMode = 'Allow'
             }
         }
+
         $mockDenyOverrideMode = @{
             Metadata = @{
                 effectiveOverrideMode = 'Deny'
@@ -121,6 +122,7 @@ try
         }
         #endregion
 
+        #region Helper functions
         Describe 'MSFT_xIISFeatureDelegation\Get-OverrideMode' {
             $mockWebConfigOutput = @{
                 Metadata = @{
@@ -166,6 +168,7 @@ try
                 }
             }
         }
+        #endregion
     }
     #endregion
 }


### PR DESCRIPTION
Updated xIisFeatureDelegation to support managing any IIS configuration section instead of paths relative to /system.webserver (hard-coded).  Also allows specifying IIS path to apply at site or server level.  This is a breaking change as parameters have changed and one was added.

Fixes #358

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/359)
<!-- Reviewable:end -->
