### PR TITLE
Add Integer value support to xWebConfigProperty (fixes #374)

### DIFF
--- a/DSCResources/MSFT_xWebConfigProperty/MSFT_xWebConfigProperty.psm1
+++ b/DSCResources/MSFT_xWebConfigProperty/MSFT_xWebConfigProperty.psm1
@@ -134,6 +134,24 @@ function Set-TargetResource
         Write-Verbose `
             -Message ($LocalizedData.VerboseSetTargetEditItem -f $PropertyName )
 
+        $propertyType = Get-ItemPropertyType -WebsitePath $WebsitePath -Filter $Filter -PropertyName $PropertyName
+
+        switch ($propertyType )
+        {
+            'Int32'
+            {
+                [Int32] $value = [convert]::ToInt32($value, 10)
+            }
+            'UInt32'
+            {
+                [UInt32] $value = [convert]::ToUInt32($value, 10)
+            }
+            'Int64'
+            {
+                [Int64] $value = [convert]::ToInt64($value, 10)
+            }
+        }
+
         Set-WebConfigurationProperty `
             -Filter $Filter `
             -PSPath $WebsitePath `
@@ -289,6 +307,48 @@ function Get-ItemValue
         return $value.Value
     }
     return $value
+}
+
+<#
+.SYNOPSIS
+    Gets the current data type of the property.
+
+.PARAMETER WebsitePath
+    Path to website location (IIS or WebAdministration format).
+
+.PARAMETER Filter
+    Filter used to locate property to retrieve.
+
+.PARAMETER PropertyName
+    Name of the property to retrieve.
+#>
+function Get-ItemPropertyType
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $WebsitePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Filter,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $PropertyName
+    )
+
+    $webConfiguration = Get-WebConfiguration -Filter $Filter -PsPath $WebsitePath
+
+    $property = $webConfiguration.Schema.AttributeSchemas | Where-Object -FilterScript {$_.Name -eq $propertyName}
+
+    return $property.ClrType.Name
 }
 
 # endregion

--- a/DSCResources/MSFT_xWebConfigProperty/MSFT_xWebConfigProperty.psm1
+++ b/DSCResources/MSFT_xWebConfigProperty/MSFT_xWebConfigProperty.psm1
@@ -136,20 +136,9 @@ function Set-TargetResource
 
         $propertyType = Get-ItemPropertyType -WebsitePath $WebsitePath -Filter $Filter -PropertyName $PropertyName
 
-        switch ($propertyType )
+        if ($propertyType -match 'Int32|Int64')
         {
-            'Int32'
-            {
-                [Int32] $value = [convert]::ToInt32($value, 10)
-            }
-            'UInt32'
-            {
-                [UInt32] $value = [convert]::ToUInt32($value, 10)
-            }
-            'Int64'
-            {
-                [Int64] $value = [convert]::ToInt64($value, 10)
-            }
+            $value = Convert-PropertyValue -PropertyType $propertyType -InputValue $Value
         }
 
         Set-WebConfigurationProperty `
@@ -349,6 +338,50 @@ function Get-ItemPropertyType
     $property = $webConfiguration.Schema.AttributeSchemas | Where-Object -FilterScript {$_.Name -eq $propertyName}
 
     return $property.ClrType.Name
+}
+
+<#
+    .SYNOPSIS
+        Converts the property from string to appropriate data type.
+
+    .PARAMETER PropertyType
+        Property type to be converted to.
+
+    .PARAMETER InputValue
+        Value to be converted.
+#>
+function Convert-PropertyValue
+{
+    [CmdletBinding()]
+    [OutputType([System.ValueType])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $PropertyType,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $InputValue
+    )
+
+    switch ($PropertyType )
+    {
+        'Int32'
+        {
+            [Int32] $value = [convert]::ToInt32($InputValue, 10)
+        }
+        'UInt32'
+        {
+            [UInt32] $value = [convert]::ToUInt32($InputValue, 10)
+        }
+        'Int64'
+        {
+            [Int64] $value = [convert]::ToInt64($InputValue, 10)
+        }
+    }
+
+    return $value
 }
 
 # endregion

--- a/DSCResources/MSFT_xWebConfigProperty/MSFT_xWebConfigProperty.psm1
+++ b/DSCResources/MSFT_xWebConfigProperty/MSFT_xWebConfigProperty.psm1
@@ -341,14 +341,14 @@ function Get-ItemPropertyType
 }
 
 <#
-    .SYNOPSIS
-        Converts the property from string to appropriate data type.
+.SYNOPSIS
+    Converts the property from string to appropriate data type.
 
-    .PARAMETER PropertyType
-        Property type to be converted to.
+.PARAMETER PropertyType
+    Property type to be converted to.
 
-    .PARAMETER InputValue
-        Value to be converted.
+.PARAMETER InputValue
+    Value to be converted.
 #>
 function Convert-PropertyValue
 {

--- a/Tests/Integration/MSFT_xWebConfigProperty.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebConfigProperty.Integration.Tests.ps1
@@ -1,23 +1,16 @@
 
 $script:dscModuleName = 'xWebAdministration'
-$script:dscResourceFriendlyName = 'xWebConfigProperty'
-$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
+$script:dscResourceName = "MSFT_xWebConfigProperty"
 
 #region HEADER
 # Integration Test Template Version: 1.3.0
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    if (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests.zip'))
-    {
-        Expand-Archive -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests.zip') -DestinationPath (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests') -Force
-    }
-    else
-    {
-        & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
-    }
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
 }
+
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 # Ensure the WebAdministration module is imported into the current session!
@@ -33,7 +26,9 @@ $TestEnvironment = Initialize-TestEnvironment `
 # Using try/finally to always cleanup.
 try
 {
-    #region Integration Tests
+    # Ensure the WinRM service required by DSC is running.
+    Get-Service -Name 'WinRM' | Where-Object { $_.Status -ne 'Running' } | Start-Service
+
     $configurationFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configurationFile
 
@@ -41,90 +36,145 @@ try
 
     # Constants for Tests
     $websiteName = New-Guid
-    $env:xWebConfigPropertyWebsitePath  = "IIS:\Sites\$($websiteName)"
-    $env:xWebConfigPropertyFilter       = 'system.webServer/directoryBrowse'
-    $env:xWebConfigPropertyPropertyName = 'enabled'
+    # Create the website we'll use for testing purposes.
+    if (-not(Get-Website -Name $websiteName))
+    {
+        $websitePhysicalPath = "$($TestDrive)\$($websiteName)"
+        New-Item -Path $websitePhysicalPath -ItemType Directory -Force | Out-Null
+        New-Website -Name $websiteName -PhysicalPath $websitePhysicalPath | Out-Null
+    }
 
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                WebsitePath          = "IIS:\Sites\$($websiteName)"
+                Filter               = 'system.webServer/directoryBrowse'
+                PropertyName         = 'enabled'
+                AddValue             = $true
+                UpdateValue          = $false
+                IntegerFilter        = '/SYSTEM.WEB/TRACE'
+                IntergerPropertyName = 'requestLimit'
+                IntegerValue         = [string](Get-Random -Minimum 11 -Maximum 1000)
+            }
+        )
+    }
+
+    #region Integration Tests
     Describe "$($script:dscResourceName)_Integration" {
-        # Ensure the WinRM service required by DSC is running.
-        Get-Service -Name 'WinRM' | Where-Object { $_.Status -ne 'Running' } | Start-Service
-
-        # Create the website we'll use for testing purposes.
-        if (-not(Get-Website -Name $websiteName))
-        {
-            $websitePhysicalPath = "$($TestDrive)\$($websiteName)"
-            New-Item -Path $websitePhysicalPath -ItemType Directory -Force | Out-Null
-            New-Website -Name $websiteName -PhysicalPath $websitePhysicalPath | Out-Null
+        $startDscConfigurationParameters = @{
+            Path              = $TestDrive
+            ConfigurationData = $ConfigurationData
+            ComputerName      = 'localhost'
+            Wait              = $true
+            Verbose           = $true
+            Force             = $true
+            ErrorAction       = 'Stop'
         }
 
-        # Get the current value & either default or set it to the opposite of what it is already.
-        $value = (Get-WebConfigurationProperty -PSPath $($env:xWebConfigPropertyWebsitePath) -Filter $($env:xWebConfigPropertyFilter) -Name $($env:xWebConfigPropertyPropertyName)).Value
-        if ($null -ne $value)
-        {
-            $env:xWebConfigPropertyPropertyValueAdd = -not([bool]$value)
-        }
-        else
-        {
-            $env:xWebConfigPropertyPropertyValueAdd = $false
-        }
+        $websitePath          = $ConfigurationData.AllNodes.WebsitePath
+        $filter               = $ConfigurationData.AllNodes.Filter
+        $propertyName         = $ConfigurationData.AllNodes.PropertyName
+        $addValue             = $ConfigurationData.AllNodes.AddValue
+        $updateValue          = $ConfigurationData.AllNodes.UpdateValue
+        $integerFilter        = $ConfigurationData.AllNodes.IntegerFilter
+        $intergerPropertyName = $ConfigurationData.AllNodes.IntergerPropertyName
+        $integerValue         = $ConfigurationData.AllNodes.IntegerValue
 
-        It 'Should compile and apply the MOF without throwing' {
-            {
-                Invoke-Expression -Command "$($script:dscResourceName)_Add -OutputPath `$TestDrive"
-                #& "$($script:dscResourceName)_Add" -OutputPath $TestDrive
-                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } `
-            | Should -Not -Throw
-        }
 
-        It 'Should be able to call Get-DscConfiguration without throwing' {
-            {
-                Get-DscConfiguration -Verbose -ErrorAction Stop
-            } `
-            | Should -Not -Throw
-        }
-
-        It 'Should have the correct value of the configuration property' {
-            # Get the new value.
-            [string] $value = (Get-WebConfigurationProperty -PSPath $env:xWebConfigPropertyWebsitePath -Filter $env:xWebConfigPropertyFilter -Name $env:xWebConfigPropertyPropertyName).Value
-
-            $value | Should -Be $env:xWebConfigPropertyPropertyValueAdd
-        }
-
-        It 'Should update the configuration property correctly' {
-            {
-                # Get the current value set it to the opposite of what it is already.
-                $value = (Get-WebConfigurationProperty -PSPath $($env:xWebConfigPropertyWebsitePath) -Filter $($env:xWebConfigPropertyFilter) -Name $($env:xWebConfigPropertyPropertyName)).Value
-                if ($null -ne $value)
+        Context 'When Adding Property' {
+            It 'Should compile and apply the MOF without throwing' {
                 {
-                    $env:xWebConfigPropertyPropertyValueUpdate = -not([bool]$value)
-                }
+                    & "$($script:dscResourceName)_Add" -OutputPath $TestDrive
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
 
-                Invoke-Expression -Command "$($script:dscResourceName)_Update -OutputPath `$TestDrive"
-                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } `
-            | Should -Not -Throw
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
 
-            # Get the new value.
-            [string] $value = (Get-WebConfigurationProperty -PSPath $env:xWebConfigPropertyWebsitePath -Filter $env:xWebConfigPropertyFilter -Name $env:xWebConfigPropertyPropertyName).Value
+            It 'Should return $true for Test-DscConfiguration' {
+                Test-DscConfiguration | Should Be $true
+            }
 
-            $value | Should -Be $env:xWebConfigPropertyPropertyValueUpdate
+            It 'Should have the correct value of the configuration property' {
+                # Get the new value.
+                [string] $value = (Get-WebConfigurationProperty -PSPath $websitePath -Filter $filter -Name $propertyName).Value
+
+                $value | Should -Be $addValue
+            }
         }
 
-        It 'Should remove configuration property' {
-            {
-                Invoke-Expression -Command "$($script:dscResourceName)_Remove -OutputPath `$TestDrive"
-                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } `
-            | Should -Not -Throw
+        Context 'When Updating a Property' {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:dscResourceName)_Update" -OutputPath $TestDrive
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
 
-            # Get the value.
-            # Because configuration properties can be inherited (& I'm not aware of a reliable way to determine if the value returned is inherited or set explicitly),
-            # we instead read the config file as XML directly & attempt to locate the property under test.
+            It 'Should update the configuration property correctly' {
+                [string] $value = (Get-WebConfigurationProperty -PSPath $websitePath -Filter $filter -Name $propertyName).Value
 
-            $value = ([xml] ((Get-WebConfigFile -PSPath $env:xWebConfigPropertyWebsitePath) | Get-Content)).SelectSingleNode("//$($env:xWebConfigPropertyFilter)/@$($env:xWebConfigPropertyPropertyName)")
+                $value | Should -Be $updateValue
+            }
 
-            $value | Should -Be $null
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should return $true for Test-DscConfiguration' {
+                Test-DscConfiguration | Should Be $true
+            }
+        }
+
+        Context 'When Removing a Property' {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:dscResourceName)_Remove" -OutputPath $TestDrive
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should remove configuration property' {
+                # Get the value.
+                # Because configuration properties can be inherited (& I'm not aware of a reliable way to determine if the value returned is inherited or set explicitly),
+                # we instead read the config file as XML directly & attempt to locate the property under test.
+
+                $value = ([xml] ((Get-WebConfigFile -PSPath $websitePath) | Get-Content)).SelectSingleNode("//$($filter)/@$($propertyName)")
+                $value | Should -Be $null
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should return $true for Test-DscConfiguration' {
+                Test-DscConfiguration | Should Be $true
+            }
+        }
+
+        Context 'When Updating a Integer Property' {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:dscResourceName)_Integer" -OutputPath $TestDrive
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should update the configuration integer property correctly' {
+                [string] $value = (Get-WebConfigurationProperty -PSPath $websitePath -Filter $integerFilter -Name $intergerPropertyName).Value
+
+                $value | Should -Be $integerValue
+            }
+
+            It 'Should return $true for Test-DscConfiguration' {
+                Test-DscConfiguration | Should Be $true
+            }
         }
 
         # Remove the website we created for testing purposes.

--- a/Tests/Integration/MSFT_xWebConfigProperty.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebConfigProperty.Integration.Tests.ps1
@@ -25,7 +25,6 @@ $TestEnvironment = Initialize-TestEnvironment `
 # Using try/finally to always cleanup.
 try
 {
-    # Ensure the WinRM service required by DSC is running.
     $configurationFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configurationFile
 
@@ -33,9 +32,8 @@ try
 
     #region Integration Tests
     Describe "$($script:dscResourceName)_Integration" {
-        # Constants for Tests
-        $websiteName = New-Guid
         # Create the website we'll use for testing purposes.
+        $websiteName = New-Guid
         if (-not(Get-Website -Name $websiteName))
         {
             $websitePhysicalPath = "$($TestDrive)\$($websiteName)"

--- a/Tests/Integration/MSFT_xWebConfigProperty.config.ps1
+++ b/Tests/Integration/MSFT_xWebConfigProperty.config.ps1
@@ -2,13 +2,16 @@ Configuration MSFT_xWebConfigProperty_Add
 {
     Import-DscResource -ModuleName xWebAdministration
 
-    xWebConfigProperty IntegrationTest
+    node localhost
     {
-        WebsitePath  = $Node.WebsitePath
-        Filter       = $Node.Filter
-        PropertyName = $Node.PropertyName
-        Value        = $Node.AddValue
-        Ensure       = 'Present'
+        xWebConfigProperty IntegrationTest
+        {
+            WebsitePath  = $Node.WebsitePath
+            Filter       = $Node.Filter
+            PropertyName = $Node.PropertyName
+            Value        = $Node.AddValue
+            Ensure       = 'Present'
+        }
     }
 }
 
@@ -16,13 +19,16 @@ Configuration MSFT_xWebConfigProperty_Update
 {
     Import-DscResource -ModuleName xWebAdministration
 
-    xWebConfigProperty IntegrationTest
+    node localhost
     {
-        WebsitePath  = $Node.WebsitePath
-        Filter       = $Node.Filter
-        PropertyName = $Node.PropertyName
-        Value        = $Node.UpdateValue
-        Ensure       = 'Present'
+        xWebConfigProperty IntegrationTest
+        {
+            WebsitePath  = $Node.WebsitePath
+            Filter       = $Node.Filter
+            PropertyName = $Node.PropertyName
+            Value        = $Node.UpdateValue
+            Ensure       = 'Present'
+        }
     }
 }
 
@@ -30,13 +36,16 @@ Configuration MSFT_xWebConfigProperty_Integer
 {
     Import-DscResource -ModuleName xWebAdministration
 
-    xWebConfigProperty IntegrationTest
+    node localhost
     {
-        WebsitePath  = $Node.WebsitePath
-        Filter       = $Node.IntegerFilter
-        PropertyName = $Node.IntergerPropertyName
-        Value        = $Node.IntegerValue
-        Ensure       = 'Present'
+        xWebConfigProperty IntegrationTest
+        {
+            WebsitePath  = $Node.WebsitePath
+            Filter       = $Node.IntegerFilter
+            PropertyName = $Node.IntergerPropertyName
+            Value        = $Node.IntegerValue
+            Ensure       = 'Present'
+        }
     }
 }
 
@@ -44,11 +53,14 @@ Configuration MSFT_xWebConfigProperty_Remove
 {
     Import-DscResource -ModuleName xWebAdministration
 
-    xWebConfigProperty IntegrationTest
+    node localhost
     {
-        WebsitePath  = $Node.WebsitePath
-        Filter       = $Node.Filter
-        PropertyName = $Node.PropertyName
-        Ensure       = 'Absent'
+        xWebConfigProperty IntegrationTest
+        {
+            WebsitePath  = $Node.WebsitePath
+            Filter       = $Node.Filter
+            PropertyName = $Node.PropertyName
+            Ensure       = 'Absent'
+        }
     }
 }

--- a/Tests/Integration/MSFT_xWebConfigProperty.config.ps1
+++ b/Tests/Integration/MSFT_xWebConfigProperty.config.ps1
@@ -4,10 +4,10 @@ Configuration MSFT_xWebConfigProperty_Add
 
     xWebConfigProperty IntegrationTest
     {
-        WebsitePath  = $env:xWebConfigPropertyWebsitePath
-        Filter       = $env:xWebConfigPropertyFilter
-        PropertyName = $env:xWebConfigPropertyPropertyName
-        Value        = $env:xWebConfigPropertyPropertyValueAdd
+        WebsitePath  = $Node.WebsitePath
+        Filter       = $Node.Filter
+        PropertyName = $Node.PropertyName
+        Value        = $Node.AddValue
         Ensure       = 'Present'
     }
 }
@@ -18,10 +18,24 @@ Configuration MSFT_xWebConfigProperty_Update
 
     xWebConfigProperty IntegrationTest
     {
-        WebsitePath  = $env:xWebConfigPropertyWebsitePath
-        Filter       = $env:xWebConfigPropertyFilter
-        PropertyName = $env:xWebConfigPropertyPropertyName
-        Value        = $env:xWebConfigPropertyPropertyValueUpdate
+        WebsitePath  = $Node.WebsitePath
+        Filter       = $Node.Filter
+        PropertyName = $Node.PropertyName
+        Value        = $Node.UpdateValue
+        Ensure       = 'Present'
+    }
+}
+
+Configuration MSFT_xWebConfigProperty_Integer
+{
+    Import-DscResource -ModuleName xWebAdministration
+
+    xWebConfigProperty IntegrationTest
+    {
+        WebsitePath  = $Node.WebsitePath
+        Filter       = $Node.IntegerFilter
+        PropertyName = $Node.IntergerPropertyName
+        Value        = $Node.IntegerValue
         Ensure       = 'Present'
     }
 }
@@ -32,9 +46,9 @@ Configuration MSFT_xWebConfigProperty_Remove
 
     xWebConfigProperty IntegrationTest
     {
-        WebsitePath  = $env:xWebConfigPropertyWebsitePath
-        Filter       = $env:xWebConfigPropertyFilter
-        PropertyName = $env:xWebConfigPropertyPropertyName
+        WebsitePath  = $Node.WebsitePath
+        Filter       = $Node.Filter
+        PropertyName = $Node.PropertyName
         Ensure       = 'Absent'
     }
 }

--- a/Tests/Unit/MSFT_xWebConfigProperty.tests.ps1
+++ b/Tests/Unit/MSFT_xWebConfigProperty.tests.ps1
@@ -180,8 +180,8 @@ try
         Describe "$($script:DSCResourceName)\Set-TargetResource" {
             Context 'Ensure is present - String Value' {
                 Mock -CommandName Get-ItemPropertyType -MockWith { return 'String' }
-                Mock -CommandName Convert-PropertyValue -MockWith {}
-                Mock -CommandName Set-WebConfigurationProperty -MockWith {}
+                Mock -CommandName Convert-PropertyValue
+                Mock -CommandName Set-WebConfigurationProperty
 
                 Set-TargetResource @script:presentParameters
 
@@ -195,7 +195,7 @@ try
             Context 'Ensure is present - Integer Value' {
                 Mock -CommandName Get-ItemPropertyType -MockWith { return 'Int32' }
                 Mock -CommandName Convert-PropertyValue -MockWith { return '32' }
-                Mock -CommandName Set-WebConfigurationProperty -MockWith {}
+                Mock -CommandName Set-WebConfigurationProperty
 
                 Set-TargetResource @script:presentParameters
 
@@ -207,7 +207,7 @@ try
             }
 
             Context 'Ensure is absent' {
-                Mock -CommandName Clear-WebConfiguration -MockWith {}
+                Mock -CommandName Clear-WebConfiguration
 
                 Set-TargetResource @script:absentParameters
 


### PR DESCRIPTION
Update to xWebConfigProperty so it can manage web configuration properties that are integer data types. This will check the attribute schema for the specified property to determine which data type to convert the string value to.(Fixes #374)

I didn't update the readme because this is a change to an unreleased resource, so not sure if it made sense to add anything there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/376)
<!-- Reviewable:end -->
