### PR TITLE
xWebAdministration: Minor typo updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **SslFlags**: SslFlags for the application: The acceptable values for this property are: `''`, `Ssl`, `SslNegotiateCert`, `SslRequireCert`, `Ssl128`
 * **EnabledProtocols**: EnabledProtocols for the application. The acceptable values for this property are: `http`, `https`, `net.tcp`, `net.msmq`, `net.pipe`
 
-#### WebApplicationHandler
+### WebApplicationHandler
 
 * **[String] Ensure** _(Write)_: Indicates if the application handler exists. Set this property to `Absent` to ensure that the application handler does not exist. Default value is 'Present'.
 { *Present* | Absent }
@@ -315,6 +315,11 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 ## Versions
 
 ### Unreleased
+
+* Changes to xWebAdministration
+  * Update section header for WebApplicationHandler in README.
+  * Fix tests for helper function `Get-LocalizedData` in Helper.Tests.ps1
+    that referenced the wrong path.
 
 ### 2.1.0.0
 

--- a/Tests/Unit/Helper.Tests.ps1
+++ b/Tests/Unit/Helper.Tests.ps1
@@ -496,18 +496,18 @@ try
                         return 'en-US'
                     } -Verifiable
 
-                    { Get-LocalizedData -ResourceName 'DummyResource' -ResourcePath ..\..\DSCResources\MSFT_xWebApplicationHandler\en-us\MSFT_xWebApplicationHandler.strings.psd1} | Should Not Throw
+                    { Get-LocalizedData -ResourceName 'DummyResource' -ResourcePath '..\..\DSCResources\MSFT_WebApplicationHandler\en-us\MSFT_WebApplicationHandler.strings.psd1'} | Should Not Throw
                 }
 
                 It 'Should call Get-LocalizedData and fallback to en-US if input language does not exist' {
 
                     Mock -CommandName Test-Path -MockWith {$false} -Verifiable
                     Mock -CommandName Join-Path -MockWith {
-                        '..\..\DSCResources\MSFT_xWebApplicationHandler\en-us\Dummy.strings.psd1\DummyPath'
+                        '..\..\DSCResources\MSFT_WebApplicationHandler\en-us\Dummy.strings.psd1'
                     } -Verifiable
                     Mock -CommandName Import-LocalizedData -Verifiable
 
-                    { Get-LocalizedData -ResourceName 'DummyResource' -ResourcePath ..\..\DSCResources\MSFT_xWebApplicationHandler\en-us\Dummy.strings.psd1} | Should -Not -Throw
+                    { Get-LocalizedData -ResourceName 'DummyResource' -ResourcePath '..\..\DSCResources\MSFT_WebApplicationHandler\en-us\Dummy.strings.psd1' } | Should -Not -Throw
 
                     Assert-MockCalled -CommandName Join-Path -Exactly -Times 2 -Scope It
                     Assert-MockCalled -CommandName Test-Path -Exactly -Times 1 -Scope It


### PR DESCRIPTION
- Update section header for WebApplicationHandler in README.
- Fix tests for helper function `Get-LocalizedData` in Helper.Tests.ps1
  that referenced the wrong path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/388)
<!-- Reviewable:end -->
