### PR TITLE
xWebConfigPropertyLocation: Added to allow access to locked sections of ApplicationHost.Config

### DIFF
--- a/DSCResources/MSFT_xWebConfigPropertyLocation/MSFT_xWebConfigPropertyLocation.psm1
+++ b/DSCResources/MSFT_xWebConfigPropertyLocation/MSFT_xWebConfigPropertyLocation.psm1
@@ -1,0 +1,431 @@
+# Localized messages
+data LocalizedData
+{
+    # culture="en-US"
+    ConvertFrom-StringData -StringData @'
+    VerboseTargetCheckingTarget       = Checking for the existence of property "{0}" using filter "{1}" located at "{2}".
+    VerboseTargetPropertyNotFound     = Property "{0}" has not been found.
+    VerboseTargetPropertyFound        = Property "{0}" has been found.
+    VerboseSetTargetEditItem          = Ensuring property "{0}" is set.
+    VerboseSetTargetRemoveItem        = Property "{0}" exists, removing property.
+'@
+}
+
+<#
+.SYNOPSIS
+    Gets the current value of the target resource property.
+
+.PARAMETER WebsitePath
+    Required. Path to website location (IIS or WebAdministration format).
+
+.PARAMETER Filter
+    Required. Filter used to locate property to update.
+
+.PARAMETER Location
+	Required. Location tag to use for property.
+	
+.PARAMETER PropertyName
+    Required. Name of the property to update.
+#>
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $WebsitePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Filter,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Location,
+		
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $PropertyName
+    )
+    # Retrieve the value of the existing property if present.
+    Write-Verbose -Message ($LocalizedData.VerboseTargetCheckingTarget -f $PropertyName, $Filter, $WebsitePath)
+
+    $Get_ItemValue_param = @{
+        WebsitePath = $WebsitePath
+        Filter = $Filter
+        PropertyName = $PropertyName
+		Location = $Location
+    }
+    $existingValue = Get-ItemValue @Get_ItemValue_param
+
+    $result = @{
+        WebsitePath = $WebsitePath
+        Filter = $Filter
+        PropertyName = $PropertyName
+		Location = $Location
+        Ensure = 'Present'
+        Value = $existingValue
+    }
+
+    if ( -not($existingValue) ) {
+        # Property was not found.
+        Write-Verbose -Message ($LocalizedData.VerboseTargetPropertyNotFound -f $PropertyName)
+
+        $result.Ensure = 'Absent'
+    }
+    else {
+        # Property was found.
+        Write-Verbose -Message ($LocalizedData.VerboseTargetPropertyFound -f $PropertyName)
+    }
+
+    return $result
+}
+
+<#
+.SYNOPSIS
+    Sets the value of the target resource property.
+
+.PARAMETER WebsitePath
+    Required. Path to website location (IIS or WebAdministration format).
+
+.PARAMETER Filter
+    Required. Filter used to locate property to update.
+
+.PARAMETER Location
+	Required. Location tag to use for property.
+	
+.PARAMETER PropertyName
+    Required. Name of the property to update.
+
+.PARAMETER Value
+    Value of the property to update.
+
+.PARAMETER Ensure
+    Present or Absent. Defaults to Present.
+#>
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $WebsitePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Filter,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+		$Location,
+		
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $PropertyName,
+
+        [Parameter()]
+        [string]
+        $Value,
+
+        [Parameter()]
+        [ValidateSet('Present','Absent')]
+        [string]
+        $Ensure = 'Present'
+    )
+    if ($Ensure -eq 'Present') {
+        # Property needs to be updated.
+        Write-Verbose -Message ($LocalizedData.VerboseSetTargetEditItem -f $PropertyName)
+		
+		$Get_ItemPropertyType_param = @{
+			WebsitePath = $WebsitePath
+			Filter = $Filter 
+			PropertyName = $PropertyName
+			Location = $Location
+		}		
+        $propertyType = Get-ItemPropertyType @Get_ItemPropertyType_param
+
+        if ($propertyType -match 'Int32|Int64') 
+			{ $setValue = Convert-PropertyValue -PropertyType $propertyType -InputValue $Value }
+        else 
+			{ $setValue = $Value }
+
+        $Set_WebConfigurationProperty_param = @{
+            Filter = $Filter
+            PSPath = $WebsitePath
+            Name = $PropertyName
+            Value = $setValue
+			Location = $Location
+            WarningAction = "Stop"
+        }
+        Set-WebConfigurationProperty @Set_WebConfigurationProperty_param
+    }
+    else {
+        # Property needs to be removed.
+        Write-Verbose -Message ($LocalizedData.VerboseSetTargetRemoveItem -f $PropertyName)
+        
+        $Clear_WebConfiguration_param = @{
+            Filter ="$($Filter)/@$($PropertyName)"
+            PSPath = $WebsitePath
+			Location = $Location
+            WarningAction = "Stop"
+        }
+        Clear-WebConfiguration @Clear_WebConfiguration_param
+    }
+}
+
+<#
+.SYNOPSIS
+    Tests the value of the target resource property.
+
+.PARAMETER WebsitePath
+    Required. Path to website location (IIS or WebAdministration format).
+
+.PARAMETER Filter
+    Required. Filter used to locate property to update.
+	
+.PARAMETER Location
+	Required. Location tag to use for property.
+	
+.PARAMETER PropertyName
+    Required. Name of the property to update.
+
+.PARAMETER Value
+    Value of the property to update.
+
+.PARAMETER Ensure
+    Present or Absent. Defaults to Present.
+#>
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $WebsitePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Filter,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+		$Location,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $PropertyName,
+
+        [Parameter()]
+        [string]
+        $Value,
+
+        [Parameter()]
+        [ValidateSet('Present','Absent')]
+        [string]
+        $Ensure = 'Present'
+    )
+    # Retrieve the value of the existing property if present.
+    Write-Verbose -Message ($LocalizedData.VerboseTargetCheckingTarget -f $PropertyName, $Filter, $WebsitePath)
+
+    $Get_TargetResource_param = @{
+        WebsitePath = $WebsitePath
+        Filter = $Filter
+        PropertyName = $PropertyName
+		Location = $Location
+    }
+    $targetResource = Get-TargetResource @Get_TargetResource_param
+
+    if ($Ensure -eq 'Present') {
+        if ( ($null -eq $targetResource.Value) -or ($targetResource.Value.ToString() -ne $Value) ) {
+            # Property was not found or didn't have expected value.
+            Write-Verbose -Message ($LocalizedData.VerboseTargetPropertyNotFound -f $PropertyName)
+
+            return $false
+        }
+    }
+    else {
+        if ( ($null -ne $targetResource.Value) -and ($targetResource.Value.ToString().Length -ne 0 ) ) {
+            # Property was found.
+			Write-Verbose -Message ($LocalizedData.VerboseTargetPropertyWasFound -f $PropertyName)
+
+            return $false
+        }
+    }
+
+    Write-Verbose -Message ($LocalizedData.VerboseTargetPropertyWasFound -f $PropertyName)
+
+    return $true
+}
+
+#region Helper Functions
+
+<#
+.SYNOPSIS
+    Gets the current value of the property.
+
+.PARAMETER WebsitePath
+    Required. Path to website location (IIS or WebAdministration format).
+
+.PARAMETER Filter
+    Required. Filter used to locate property to retrieve.
+
+.PARAMETER Location
+	Required. Location tag to use for property.
+
+.PARAMETER PropertyName
+    Required. Name of the property to retrieve.
+#>
+function Get-ItemValue
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $WebsitePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Filter,
+
+		[Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Location,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $PropertyName
+    )
+	
+    # Retrieve the value of the specified property if present.
+    $Get_WebConfigurationProperty_param = @{
+        PSPath = $WebsitePath
+        Filter = $Filter
+        Name = $PropertyName
+		Location = $Location
+    }
+    $value = Get-WebConfigurationProperty @Get_WebConfigurationProperty_param
+
+    # Return the value of the property if located.
+    if ($value -is [Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute]) {
+        return $value.Value
+    }
+    return $value
+}
+
+<#
+.SYNOPSIS
+    Gets the current data type of the property.
+
+.PARAMETER WebsitePath
+    Path to website location (IIS or WebAdministration format).
+
+.PARAMETER Filter
+    Filter used to locate property to retrieve.
+
+.PARAMETER Location
+	Required. Location tag to use for property.
+
+.PARAMETER PropertyName
+    Name of the property to retrieve.
+#>
+function Get-ItemPropertyType
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $WebsitePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Filter,
+		
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Location,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $PropertyName
+    )
+
+    $Get_WebConfiguration_param = @{
+        Filter = $Filter 
+        PsPath = $WebsitePath
+		Location = $Location
+    }
+    $webConfiguration = Get-WebConfiguration @Get_WebConfiguration_param
+
+    $property = $webConfiguration.Schema.AttributeSchemas | Where-Object -FilterScript {$_.Name -eq $propertyName}
+
+    return $property.ClrType.Name
+}
+
+<#
+.SYNOPSIS
+    Converts the property from string to appropriate data type.
+
+.PARAMETER PropertyType
+    Property type to be converted to.
+
+.PARAMETER InputValue
+    Value to be converted.
+#>
+function Convert-PropertyValue
+{
+    [CmdletBinding()]
+    [OutputType([System.ValueType])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $PropertyType,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $InputValue
+    )
+
+    switch ($PropertyType ) {
+        'Int32'
+			{ [Int32] $value = [convert]::ToInt32($InputValue, 10) }
+        'UInt32'
+			{ [UInt32] $value = [convert]::ToUInt32($InputValue, 10) }
+        'Int64'
+			{ [Int64] $value = [convert]::ToInt64($InputValue, 10) }
+    }
+
+    return $value
+}
+
+#endregion
+
+Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xWebConfigPropertyLocation/MSFT_xWebConfigPropertyLocation.schema.mof
+++ b/DSCResources/MSFT_xWebConfigPropertyLocation/MSFT_xWebConfigPropertyLocation.schema.mof
@@ -1,0 +1,10 @@
+[ClassVersion("1.0.0.0"), FriendlyName("xWebConfigPropertyLocation")]
+class MSFT_xWebConfigPropertyLocation : OMI_BaseResource
+{
+    [Key, Description("Path to website location (IIS or WebAdministration format).")] String WebsitePath;
+    [Key, Description("Filter used to locate property to update.")] String Filter;
+    [Key, Description("Name of the property to update.")] String PropertyName;
+    [Key, Description("Location is used to update locked sections in the root config.")] String Location;
+    [Write, Description("Indicates if the property and value should be present or absent. Defaults to Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Value of the property to update.")] String Value;
+};


### PR DESCRIPTION
xWebConfigPropertyLocation: Added to allow access to locked sections of ApplicationHost.Config

#### Pull Request (PR) description
This new resource adds an additional parameter for the Location of the configuration property.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [X] Comment-based help added/updated.
- [X] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
