### PR TITLE
xWebSite: Fix (#397)  Get-WebConfiguration uses full path to get list of default documents

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -123,7 +123,7 @@ function Get-TargetResource
         $cimBindings = @(ConvertTo-CimBinding -InputObject $website.bindings.Collection)
 
         $allDefaultPages = @(
-            Get-WebConfiguration -Filter '//defaultDocument/files/*' -PSPath "IIS:\Sites\$Name" |
+            Get-WebConfiguration -Filter '/system.webServer/defaultDocument/files/*' -PSPath "IIS:\Sites\$Name" |
             ForEach-Object -Process {Write-Output -InputObject $_.value}
         )
         $cimAuthentication = Get-AuthenticationInfo -Site $Name
@@ -805,7 +805,7 @@ function Test-TargetResource
             $null -ne $DefaultPage)
         {
             $allDefaultPages = @(
-                Get-WebConfiguration -Filter '//defaultDocument/files/*' `
+                Get-WebConfiguration -Filter '/system.webServer/defaultDocument/files/*' `
                                      -PSPath "IIS:\Sites\$Name" |
                 ForEach-Object -Process { Write-Output -InputObject $_.value }
             )
@@ -2042,7 +2042,7 @@ function Update-DefaultPage
     )
 
     $allDefaultPages = @(
-        Get-WebConfiguration -Filter '//defaultDocument/files/*' `
+        Get-WebConfiguration -Filter '/system.webServer/defaultDocument/files/*' `
                              -PSPath "IIS:\Sites\$Name" |
         ForEach-Object -Process { Write-Output -InputObject $_.value }
     )
@@ -2051,7 +2051,7 @@ function Update-DefaultPage
     {
         if ($allDefaultPages -inotcontains $page)
         {
-            Add-WebConfiguration -Filter '//defaultDocument/files' `
+            Add-WebConfiguration -Filter '/system.webServer/defaultDocument/files' `
                                  -PSPath "IIS:\Sites\$Name" `
                                  -Value @{ value = $page }
             Write-Verbose -Message ($LocalizedData.VerboseUpdateDefaultPageUpdated `

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 ## Versions
 
 ### Unreleased
-
+* xWebSite: Full path is used to get list of default documents
 ### 2.3.0.0
 
 * Update appveyor.yml to use the default template.

--- a/Tests/Integration/MSFT_xWebsite.config.ps1
+++ b/Tests/Integration/MSFT_xWebsite.config.ps1
@@ -3,16 +3,16 @@
 configuration MSFT_xWebsite_Present_Started
 {
     param(
-        
+
         [Parameter(Mandatory = $true)]
         [String] $CertificateThumbprint
-    
+
     )
 
     Import-DscResource -ModuleName xWebAdministration
 
     Node $AllNodes.NodeName
-    {  
+    {
         xWebsite Website
         {
             Name = $Node.Website
@@ -89,16 +89,16 @@ configuration MSFT_xWebsite_Present_Started
 configuration MSFT_xWebsite_Present_Stopped
 {
     param(
-        
+
         [Parameter(Mandatory = $true)]
         [String]$CertificateThumbprint
-    
+
     )
 
     Import-DscResource -ModuleName xWebAdministration
 
-    Node $AllNodes.NodeName 
-    {  
+    Node $AllNodes.NodeName
+    {
         xWebsite Website
         {
             Name = $Node.Website
@@ -177,12 +177,122 @@ configuration MSFT_xWebsite_Absent
 {
     Import-DscResource -ModuleName xWebAdministration
 
-    Node $AllNodes.NodeName 
-    {  
+    Node $AllNodes.NodeName
+    {
         xWebsite Website
         {
             Name = $Node.Website
             Ensure = 'Absent'
+        }
+    }
+}
+
+configuration MSFT_xWebsite_Webconfig_Get_Test_Set
+{
+    param(
+
+        [Parameter(Mandatory = $true)]
+        [String] $CertificateThumbprint
+
+    )
+
+    Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName xWebAdministration
+
+    Node $AllNodes.NodeName
+    {
+        File WebConfig {
+            Ensure = 'Present'
+            DestinationPath = Join-Path -Path $Node.PhysicalPath -ChildPath 'web.config'
+            Type = 'File'
+            Contents = '<?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+                <system.codedom>
+                    <compilers>
+                        <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+                        <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+                    </compilers>
+                </system.codedom>
+
+                <system.web>
+                    <clientTarget>
+                        <add alias="uplevel" userAgent="Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)"/>
+                        <add alias="downlevel" userAgent="Generic Downlevel"/>
+                    </clientTarget>
+                </system.web>
+            </configuration>'
+        }
+
+        xWebsite Website
+        {
+            DependsOn = '[File]WebConfig'
+            Name = $Node.Website
+            Ensure = 'Present'
+            ApplicationType = $Node.ApplicationType
+            ApplicationPool = $Node.ApplicationPool
+            AuthenticationInfo = `
+                MSFT_xWebAuthenticationInformation
+                {
+                    Anonymous = $Node.AuthenticationInfoAnonymous
+                    Basic     = $Node.AuthenticationInfoBasic
+                    Digest    = $Node.AuthenticationInfoDigest
+                    Windows   = $Node.AuthenticationInfoWindows
+                }
+                BindingInfo = @(MSFT_xWebBindingInformation
+                {
+                    Protocol              = $Node.HTTPProtocol
+                    Port                  = $Node.HTTPPort
+                    IPAddress             = '*'
+                    Hostname              = $Node.HTTP1Hostname
+                }
+                MSFT_xWebBindingInformation
+                {
+                    Protocol              = $Node.HTTPProtocol
+                    Port                  = $Node.HTTPPort
+                    IPAddress             = '*'
+                    Hostname              = $Node.HTTP2Hostname
+                }
+                MSFT_xWebBindingInformation
+                {
+                    Protocol              = $Node.HTTPSProtocol
+                    Port                  = $Node.HTTPSPort
+                    IPAddress             = '*'
+                    Hostname              = $Node.HTTPSHostname
+                    CertificateThumbprint = $CertificateThumbprint
+                    CertificateStoreName  = $Node.CertificateStoreName
+                    SslFlags              = $Node.SslFlags
+                }
+                MSFT_xWebBindingInformation
+                {
+                    Protocol              = $Node.HTTPSProtocol
+                    Port                  = $Node.HTTPSPort2
+                    IPAddress             = '*'
+                    Hostname              = $Node.HTTPSHostname
+                    CertificateSubject    = $Node.HTTPSHostname
+                    CertificateStoreName  = $Node.CertificateStoreName
+                    SslFlags              = $Node.SslFlags
+                })
+                DefaultPage = $Node.DefaultPage
+                EnabledProtocols = $Node.EnabledProtocols
+                PhysicalPath = $Node.PhysicalPath
+                PreloadEnabled = $Node.PreloadEnabled
+                ServiceAutoStartEnabled = $Node.ServiceAutoStartEnabled
+                ServiceAutoStartProvider = $Node.ServiceAutoStartProvider
+                State = 'Started'
+                LogCustomFields    = @(
+                    MSFT_xLogCustomFieldInformation
+                    {
+                        LogFieldName = $Node.LogFieldName1
+                        SourceName   = $Node.SourceName1
+                        SourceType   = $Node.SourceType1
+                    }
+                    MSFT_xLogCustomFieldInformation
+                    {
+                        LogFieldName = $Node.LogFieldName2
+                        SourceName   = $Node.SourceName2
+                        SourceType   = $Node.SourceType2
+                    }
+                )
         }
     }
 }

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -160,7 +160,7 @@ try
                 Mock -CommandName Get-Website -MockWith {return $MockWebsite}
 
                 Mock -CommandName Get-WebConfiguration  `
-                        -ParameterFilter {$filter -eq '//defaultDocument/files/*'} `
+                        -ParameterFilter {$filter -eq '/system.webServer/defaultDocument/files/*'} `
                         -MockWith { return @{value = 'index.html'} }
 
                 Mock -CommandName Get-WebConfiguration `


### PR DESCRIPTION
#### This Pull Request (PR) fixes the following issues
 - Fixes #397 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/410)
<!-- Reviewable:end -->
