### PR TITLE
xWebSite: adding support for Site Id in xWebSite

### DIFF
--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -177,6 +177,9 @@ function Get-TargetResource
         The Set-TargetResource cmdlet is used to create, delete or configure a website on the
         target machine.
 
+        .PARAMETER SiteId
+            Optional. Specifies the IIS site Id for the web site.
+
         .PARAMETER PhysicalPath
         Specifies the physical path of the web site. Don't set this if the site will be deployed by an external tool that updates the path.
 #>
@@ -681,6 +684,10 @@ function Set-TargetResource
         .SYNOPSIS
         The Test-TargetResource cmdlet is used to validate if the role or feature is in a state as
         expected in the instance document.
+
+        .PARAMETER SiteId
+            Optional. Specifies the IIS site Id for the web site.
+
 #>
 function Test-TargetResource
 {
@@ -785,12 +792,10 @@ function Test-TargetResource
         $null -ne $website)
     {
         # Check Site Id property.
-        if ($SiteId -gt 0 -and `
-        $website.Id -ne $SiteId)
+        if ($SiteId -gt 0 -and $website.Id -ne $SiteId)
         {
             $inDesiredState = $false
-            Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalseSiteId `
-            -f $Name)
+            Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalseSiteId -f $Name)
         }
 
         # Check Physical Path property

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -407,19 +407,15 @@ function Set-TargetResource
                 } | ForEach-Object -Begin {
                         $newWebsiteSplat = @{}
                 } -Process {
-                    # New-WebSite has Id parameter instead of SiteId, so we are replacing
-                    if ($_.Key -eq "SiteId")
-                    {
-                        $newWebsiteSplat.Add('Id', $_.Value)
-                    } else {
-                        $newWebsiteSplat.Add($_.Key, $_.Value)
-                    }
+                    $newWebsiteSplat.Add($_.Key, $_.Value)
                 }
 
-                # If there are no other websites, specify the Id Parameter for the new website if it's missing.
-                # Otherwise an error can occur on systems running Windows Server 2008 R2.
-                if (-not (Get-Website) -and -not $newWebsiteSplat.ContainsKey('Id'))
-                {
+                # New-WebSite has Id parameter instead of SiteId, so it's getting mapped to Id
+                if ($PSBoundParameters.ContainsKey('SiteId')) {
+                    $newWebsiteSplat.Add('Id', $SiteId)
+                } elseif (-not (Get-WebSite)) {
+                    # If there are no other websites and SiteId is missing, specify the Id Parameter for the new website.
+                    # Otherwise an error can occur on systems running Windows Server 2008 R2.
                     $newWebsiteSplat.Add('Id', 1)
                 }
 

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -150,6 +150,7 @@ function Get-TargetResource
     return @{
         Ensure                   = $ensureResult
         Name                     = $Name
+        SiteId                   = $website.id
         PhysicalPath             = $website.PhysicalPath
         State                    = $website.State
         ApplicationPool          = $website.ApplicationPool

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
@@ -34,6 +34,7 @@ class MSFT_xWebsite : OMI_BaseResource
 {
     [Write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
     [Key] String Name;
+    [Write] UInt32 SiteId;
     [Write] String PhysicalPath;
     [Write,ValueMap{"Started","Stopped"},Values{"Started", "Stopped"}] String State;
     [Write] String ApplicationPool;

--- a/Examples/Sample_xWebsite_NewWebsite.ps1
+++ b/Examples/Sample_xWebsite_NewWebsite.ps1
@@ -10,6 +10,10 @@ configuration Sample_xWebsite_NewWebsite
         [ValidateNotNullOrEmpty()]
         [String] $WebSiteName,
 
+        # Optional Site Id for the website
+        [Parameter()]
+        [UInt32] $SiteId,
+
         # Source Path for Website content
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -41,7 +45,7 @@ configuration Sample_xWebsite_NewWebsite
         }
 
         # Stop the default website
-        xWebsite DefaultSite 
+        xWebsite DefaultSite
         {
             Ensure          = 'Present'
             Name            = 'Default Web Site'
@@ -59,13 +63,14 @@ configuration Sample_xWebsite_NewWebsite
             Recurse         = $true
             Type            = 'Directory'
             DependsOn       = '[WindowsFeature]AspNet45'
-        }       
+        }
 
         # Create the new Website
         xWebsite NewWebsite
         {
             Ensure          = 'Present'
             Name            = $WebSiteName
+            SiteId          = $SiteId
             State           = 'Started'
             PhysicalPath    = $DestinationPath
             DependsOn       = '[File]WebContent'

--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 
 ### Unreleased
 
+### 2.3.0.0
+
 * Update appveyor.yml to use the default template.
 * Added default template file .gitattributes, and added default settings for
   Visual Studio Code.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### xWebsite
 
 * **Name** : The desired name of the website.
+* **SiteId** : Optional. The desired IIS site Id for the website.
 * **PhysicalPath**: The path to the files that compose the website.
 * **State**: The state of the website: { Started | Stopped }
 * **BindingInfo**: Website's binding information in the form of an array of embedded instances of the **MSFT_xWebBindingInformation** CIM class that implements the following properties:
@@ -316,6 +317,8 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 ## Versions
 
 ### Unreleased
+
+* Added SiteId to xWebSite to address [396]
 
 ### 2.3.0.0
 

--- a/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
@@ -104,7 +104,7 @@ try
 
             # Test Website basic settings are correct
             $result.Name             | Should Be $dscConfig.AllNodes.Website
-            $result.SiteId           | Should Be $dscConfig.AllNodes.SiteId
+            $result.Id               | Should Be $dscConfig.AllNodes.SiteId
             $result.PhysicalPath     | Should Be $dscConfig.AllNodes.PhysicalPath
             $result.State            | Should Be 'Started'
             $result.ApplicationPool  | Should Be $dscConfig.AllNodes.ApplicationPool
@@ -185,7 +185,7 @@ try
             # Test Website basic settings are correct
             $result.Name             | Should Be $dscConfig.AllNodes.Website
             $result.PhysicalPath     | Should Be $dscConfig.AllNodes.PhysicalPath
-            $result.SiteId           | Should Be $dscConfig.AllNodes.SiteId
+            $result.Id               | Should Be $dscConfig.AllNodes.SiteId
             $result.State            | Should Be 'Stopped'
             $result.ApplicationPool  | Should Be $dscConfig.AllNodes.ApplicationPool
             $result.EnabledProtocols | Should Be $dscConfig.AllNodes.EnabledProtocols

--- a/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWebsite.Integration.Tests.ps1
@@ -104,6 +104,7 @@ try
 
             # Test Website basic settings are correct
             $result.Name             | Should Be $dscConfig.AllNodes.Website
+            $result.SiteId           | Should Be $dscConfig.AllNodes.SiteId
             $result.PhysicalPath     | Should Be $dscConfig.AllNodes.PhysicalPath
             $result.State            | Should Be 'Started'
             $result.ApplicationPool  | Should Be $dscConfig.AllNodes.ApplicationPool
@@ -184,6 +185,7 @@ try
             # Test Website basic settings are correct
             $result.Name             | Should Be $dscConfig.AllNodes.Website
             $result.PhysicalPath     | Should Be $dscConfig.AllNodes.PhysicalPath
+            $result.SiteId           | Should Be $dscConfig.AllNodes.SiteId
             $result.State            | Should Be 'Stopped'
             $result.ApplicationPool  | Should Be $dscConfig.AllNodes.ApplicationPool
             $result.EnabledProtocols | Should Be $dscConfig.AllNodes.EnabledProtocols

--- a/Tests/Integration/MSFT_xWebsite.config.ps1
+++ b/Tests/Integration/MSFT_xWebsite.config.ps1
@@ -16,6 +16,7 @@ configuration MSFT_xWebsite_Present_Started
         xWebsite Website
         {
             Name = $Node.Website
+            SiteId = $Node.SiteId
             Ensure = 'Present'
             ApplicationType = $Node.ApplicationType
             ApplicationPool = $Node.ApplicationPool

--- a/Tests/Integration/MSFT_xWebsite.config.psd1
+++ b/Tests/Integration/MSFT_xWebsite.config.psd1
@@ -10,6 +10,7 @@
             ApplicationPool             = 'DefaultAppPool'
             DefaultPage                 = 'Website.html'
             EnabledProtocols            = 'http'
+            SiteId                      = 1234
             PhysicalPath                = 'C:\inetpub\wwwroot'
             PreloadEnabled              = $true
             ServiceAutoStartEnabled     = $true

--- a/xWebAdministration.psd1
+++ b/xWebAdministration.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-moduleVersion = '2.2.0.0'
+moduleVersion = '2.3.0.0'
 
 # ID used to uniquely identify this module
 GUID = 'b3239f27-d7d3-4ae6-a5d2-d9a1c97d6ae4'
@@ -41,13 +41,10 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = '* Added new parameter "Location" to **WebApplcationHandler** extending functionality to address [392]
-* Changes to xWebAdministration
-  * Update section header for WebApplicationHandler in README.
-  * Fix tests for helper function `Get-LocalizedData` in Helper.Tests.ps1
-    that referenced the wrong path.
-* Remove duplication in MSFT_xWebsite.psm1. [Krzysztof Morcinek (@kmorcinek)](https://github.com/kmorcinek)
-* Updates **xIISMimeTypeMapping** to add MIME type mapping for nested paths
+        ReleaseNotes = '* Update appveyor.yml to use the default template.
+* Added default template file .gitattributes, and added default settings for
+  Visual Studio Code.
+* Line endings was fixed in files that was committed with wrong line ending.
 
 '
 
@@ -61,6 +58,7 @@ FunctionsToExport = '*'
 # Cmdlets to export from this module
 CmdletsToExport = '*'
 }
+
 
 
 


### PR DESCRIPTION
#### Pull Request (PR) description
Adding SiteId to the xWebSite resource allowing setting the desired IIS site Id.
As per comments on the original issue #396 SiteId is being used instead of Id to avoid potential future conflicts or confusions.

#### This Pull Request (PR) fixes the following issues
    - Fixes #396

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/415)
<!-- Reviewable:end -->
