### PR TITLE
xWebAdministration: Add example usage of mandatory field ConfigurationPath in xiismimetypemapping.

### DIFF
--- a/Examples/Sample_xIisMimeTypeMapping_RemoveVideo.ps1
+++ b/Examples/Sample_xIisMimeTypeMapping_RemoveVideo.ps1
@@ -3,7 +3,12 @@ configuration Sample_RemoveVideoMimeTypeMappings
     param
     (
         # Target nodes to apply the configuration
-        [string[]]$NodeName = 'localhost'
+        [String[]] $NodeName = 'localhost',
+
+        # Name of the website to modify
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String] $WebSiteName
     )
 
     # Import the module that defines custom resources
@@ -21,35 +26,39 @@ configuration Sample_RemoveVideoMimeTypeMappings
         # Remove a bunch of Video Mime Type mappings
         xIisMimeTypeMapping Mp2 
         {
-            Ensure      = 'Absent'
-            Extension   = '.mp2'
-            MimeType    = 'video/mpeg'
-            DependsOn   = '[WindowsFeature]IIS'
+            Ensure            = 'Absent'
+            Extension         = '.mp2'
+            MimeType          = 'video/mpeg'
+            ConfigurationPath = "IIS:\sites\$WebSiteName"
+            DependsOn         = '[WindowsFeature]IIS'
         }
 
         xIisMimeTypeMapping Mp4 
         {
-            Ensure      = 'Absent'
-            Extension   = '.mp4'
-            MimeType    = 'video/mp4'
-            DependsOn   = '[WindowsFeature]IIS'
+            Ensure            = 'Absent'
+            Extension         = '.mp4'
+            MimeType          = 'video/mp4'
+            ConfigurationPath = "IIS:\sites\$WebSiteName"
+            DependsOn         = '[WindowsFeature]IIS'
         }
 
         xIisMimeTypeMapping Mpeg 
         {
-            Ensure      = 'Absent'
-            Extension   = '.mpeg'
-            MimeType    = 'video/mpeg'
-            DependsOn   = '[WindowsFeature]IIS'
+            Ensure            = 'Absent'
+            Extension         = '.mpeg'
+            MimeType          = 'video/mpeg'
+            ConfigurationPath = "IIS:\sites\$WebSiteName"
+            DependsOn         = '[WindowsFeature]IIS'
         }
 
         # we only allow the mpg Video extension on our server
         xIisMimeTypeMapping Mpg 
         {
-            Ensure      = 'Present'
-            Extension   = '.mpg'
-            MimeType    = 'video/mpeg'
-            DependsOn   = '[WindowsFeature]IIS'
+            Ensure            = 'Present'
+            Extension         = '.mpg'
+            MimeType          = 'video/mpeg'
+            ConfigurationPath = "IIS:\sites\$WebSiteName"
+            DependsOn         = '[WindowsFeature]IIS'
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ This resource manages the IIS configuration section locking (overrideMode) to co
     * Common Tests - Validate Module Files
     * Common Tests - Validate Markdown Files
     * Common Tests - Validate Markdown Links
+  * Add ConfigurationPath to xIisMimeTypeMapping examples since it is now a required field.
 
 ### 2.6.0.0
 


### PR DESCRIPTION
ConfigurationPath is now a required field of xiismimetypemapping.  However, the example does not reflect this.
Fixes #426 

- [x] Examples appropriately added/updated.
- [x ] New/changed code adheres to [DSC Resource Style Guidelines]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/427)
<!-- Reviewable:end -->
