### PR TITLE
xWebAdministration: Opt In to Script Analyzer Dsc Resource Meta Tests

### DIFF
--- a/.MetaTestOptIn.json
+++ b/.MetaTestOptIn.json
@@ -3,6 +3,9 @@
     "Common Tests - Validate Script Files",
     "Common Tests - Validate Module Files",
     "Common Tests - Validate Markdown Files",
-    "Common Tests - Validate Markdown Links"
+    "Common Tests - Validate Markdown Links",
+    "Common Tests - Custom Script Analyzer Rules",
+    "Common Tests - Flagged Script Analyzer Rules",
+    "Common Tests - Required Script Analyzer Rules"
 ]
 

--- a/DSCResources/Helper.psm1
+++ b/DSCResources/Helper.psm1
@@ -23,13 +23,13 @@ function New-TerminatingError
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String] $ErrorId,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String] $ErrorMessage,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [System.Management.Automation.ErrorCategory] $ErrorCategory
     )
 
@@ -50,6 +50,7 @@ function Assert-Module
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [String]$ModuleName = 'WebAdministration'
     )
 

--- a/DSCResources/MSFT_xIIsHandler/MSFT_xIisHandler.psm1
+++ b/DSCResources/MSFT_xIIsHandler/MSFT_xIisHandler.psm1
@@ -786,17 +786,17 @@ function Get-TargetResource
 {
     <#
     .SYNOPSIS
-        This will return a hashtable of results 
+        This will return a hashtable of results
     #>
 
     [OutputType([Hashtable])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String] $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Present', 'Absent')]
         [String] $Ensure
     )
@@ -836,15 +836,15 @@ function Set-TargetResource
         top of the list, meaning, they are tried first. There is no way of ordering the
         handler list except for removing all and then adding them in the correct order.
     #>
-    
+
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String] $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Present', 'Absent')]
         [String] $Ensure
     )
@@ -879,15 +879,15 @@ function Test-TargetResource
         This tests the desired state. If the state is not correct it will return $false.
         If the state is correct it will return $true
     #>
-    
+
     [OutputType([System.Boolean])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String] $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Present', 'Absent')]
         [String] $Ensure
     )
@@ -921,6 +921,7 @@ function Get-Handler
 {
     param
     (
+        [Parameter()]
         [String] $Name
     )
 
@@ -934,6 +935,7 @@ function Add-Handler
 {
     param
     (
+        [Parameter()]
         [String] $Name
     )
 

--- a/DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.psm1
+++ b/DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.psm1
@@ -120,6 +120,8 @@ function Set-TargetResource
 #>
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "",
+        Justification = 'Verbose messaging in helper function')]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param

--- a/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
+++ b/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
@@ -105,25 +105,32 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [String] $LogPath,
 
+        [Parameter()]
         [ValidateSet('Date','Time','ClientIP','UserName','SiteName','ComputerName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','BytesSent','BytesRecv','TimeTaken','ServerPort','UserAgent','Cookie','Referer','ProtocolVersion','Host','HttpSubStatus')]
         [String[]] $LogFlags,
 
+        [Parameter()]
         [ValidateSet('Hourly','Daily','Weekly','Monthly','MaxSize')]
         [String] $LogPeriod,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1048576, 4294967295)] $valueAsUInt64 = [UInt64]::Parse($_))
         })]
         [String] $LogTruncateSize,
 
+        [Parameter()]
         [Boolean] $LoglocalTimeRollover,
 
+        [Parameter()]
         [ValidateSet('IIS','W3C','NCSA')]
         [String] $LogFormat,
 
+        [Parameter()]
         [ValidateSet('File','ETW','File,ETW')]
         [String] $LogTargetW3C,
 
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $LogCustomFields
     )
@@ -266,27 +273,34 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [String] $LogPath,
 
+        [Parameter()]
         [ValidateSet('Date','Time','ClientIP','UserName','SiteName','ComputerName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','BytesSent','BytesRecv','TimeTaken','ServerPort','UserAgent','Cookie','Referer','ProtocolVersion','Host','HttpSubStatus')]
         [String[]] $LogFlags,
 
+        [Parameter()]
         [ValidateSet('Hourly','Daily','Weekly','Monthly','MaxSize')]
         [String] $LogPeriod,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1048576, 4294967295)] $valueAsUInt64 = [UInt64]::Parse($_))
         })]
         [String] $LogTruncateSize,
 
+        [Parameter()]
         [Boolean] $LoglocalTimeRollover,
 
+        [Parameter()]
         [ValidateSet('IIS','W3C','NCSA')]
         [String] $LogFormat,
 
+        [Parameter()]
         [ValidateSet('File','ETW','File,ETW')]
         [String] $LogTargetW3C,
 
-    [Microsoft.Management.Infrastructure.CimInstance[]]
-    $LogCustomFields
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $LogCustomFields
     )
 
         Assert-Module
@@ -400,6 +414,7 @@ function Compare-LogFlags
     [OutputType([Boolean])]
     param
     (
+        [Parameter()]
         [ValidateSet('Date','Time','ClientIP','UserName','SiteName','ComputerName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','BytesSent','BytesRecv','TimeTaken','ServerPort','UserAgent','Cookie','Referer','ProtocolVersion','Host','HttpSubStatus')]
         [String[]] $LogFlags
     )

--- a/DSCResources/MSFT_xIisModule/MSFT_xIisModule.psm1
+++ b/DSCResources/MSFT_xIisModule/MSFT_xIisModule.psm1
@@ -26,7 +26,7 @@ function Get-TargetResource
 {
     <#
     .SYNOPSIS
-        This will return a hashtable of results 
+        This will return a hashtable of results
     #>
 
     [CmdletBinding()]
@@ -45,14 +45,16 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [String[]] $Verb,
 
+        [Parameter()]
         [ValidateSet('FastCgiModule')]
         [String] $ModuleType = 'FastCgiModule',
 
+        [Parameter()]
         [String] $SiteName
     )
 
         Assert-Module
-        
+
         $currentVerbs = @()
         $Ensure = 'Absent'
 
@@ -86,7 +88,7 @@ function Get-TargetResource
         }
 
         Write-Verbose -Message $LocalizedData.VerboseGetTargetResource
-        
+
         $returnValue = @{
             Path          = $handler.ScriptProcessor
             Name          = $handler.Name
@@ -99,7 +101,7 @@ function Get-TargetResource
         }
 
         $returnValue
-    
+
 }
 
 function Set-TargetResource
@@ -112,9 +114,10 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [String] $Ensure,
-        
+
         [Parameter(Mandatory = $true)]
         [String] $Path,
 
@@ -127,9 +130,11 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [String[]] $Verb,
 
+        [Parameter()]
         [ValidateSet('FastCgiModule')]
         [String] $ModuleType = 'FastCgiModule',
 
+        [Parameter()]
         [String] $SiteName
     )
 
@@ -145,13 +150,13 @@ function Set-TargetResource
     {
         if($resourceTests.ModulePresent -and -not $resourceTests.ModuleConfigured)
         {
-            Write-Verbose -Message $LocalizedData.VerboseSetTargetRemoveHandler 
+            Write-Verbose -Message $LocalizedData.VerboseSetTargetRemoveHandler
             Remove-IisHandler
         }
 
         if(-not $resourceTests.ModulePresent -or -not $resourceTests.ModuleConfigured)
         {
-            Write-Verbose -Message $LocalizedData.VerboseSetTargetAddHandler 
+            Write-Verbose -Message $LocalizedData.VerboseSetTargetAddHandler
             Add-webconfiguration /system.webServer/handlers iis:\ -Value @{
                 Name = $Name
                 Path = $RequestPath
@@ -169,7 +174,7 @@ function Set-TargetResource
             }
         }
     }
-    else 
+    else
     {
         Write-Verbose -Message $LocalizedData.VerboseSetTargetRemoveHandler
         Remove-IisHandler
@@ -188,9 +193,10 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [String] $Ensure,
-        
+
         [Parameter(Mandatory = $true)]
         [String] $Path,
 
@@ -203,9 +209,11 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [String[]] $Verb,
 
+        [Parameter()]
         [ValidateSet('FastCgiModule')]
         [String] $ModuleType = 'FastCgiModule',
 
+        [Parameter()]
         [String] $SiteName
     )
 
@@ -213,7 +221,7 @@ function Test-TargetResource
     $resourceStatus = Get-TargetResource @GetParameters
 
     Write-Verbose -Message $LocalizedData.VerboseTestTargetResource
-    
+
     return (Test-TargetResourceImpl @PSBoundParameters -ResourceStatus $resourceStatus).Result
 }
 
@@ -247,6 +255,7 @@ function Get-IisSitePath
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [String] $SiteName
     )
 
@@ -269,11 +278,13 @@ function Get-IisHandler
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
 
+        [Parameter()]
         [String] $Name,
 
+        [Parameter()]
         [String] $SiteName
     )
 
@@ -292,14 +303,16 @@ function Remove-IisHandler
     #>
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
 
+        [Parameter()]
         [String] $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
 
+        [Parameter()]
         [String] $SiteName
     )
 
@@ -331,11 +344,14 @@ function Test-TargetResourceImpl
         [Parameter(Mandatory = $true)]
         [String[]] $Verb,
 
+        [Parameter()]
         [ValidateSet('FastCgiModule')]
         [String] $ModuleType = 'FastCgiModule',
 
+        [Parameter()]
         [String] $SiteName,
 
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [String] $Ensure,
 

--- a/DSCResources/MSFT_xSSLSettings/MSFT_xSSLSettings.psm1
+++ b/DSCResources/MSFT_xSSLSettings/MSFT_xSSLSettings.psm1
@@ -16,7 +16,7 @@ data LocalizedData
 
 <#
         .SYNOPSIS
-        This will return a hashtable of results including Name, Bindings, and Ensure 
+        This will return a hashtable of results including Name, Bindings, and Ensure
 #>
 function Get-TargetResource
 {
@@ -90,6 +90,7 @@ function Set-TargetResource
         [ValidateSet('','Ssl','SslNegotiateCert','SslRequireCert','Ssl128')]
         [String[]] $Bindings,
 
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [String] $Ensure = 'Present'
     )
@@ -109,7 +110,7 @@ function Set-TargetResource
         Write-Verbose -Message ($LocalizedData.SettingsslConfig -f $Name, 'None')
         Set-WebConfigurationProperty @params
     }
-    
+
     else
     {
         $sslBindings = $Bindings -join ','
@@ -145,6 +146,7 @@ function Test-TargetResource
         [ValidateSet('','Ssl','SslNegotiateCert','SslRequireCert','Ssl128')]
         [String[]] $Bindings,
 
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [String] $Ensure = 'Present'
     )

--- a/DSCResources/MSFT_xWebAppPool/MSFT_xWebAppPool.psm1
+++ b/DSCResources/MSFT_xWebAppPool/MSFT_xWebAppPool.psm1
@@ -98,7 +98,7 @@ function Get-TargetResource
 {
     <#
     .SYNOPSIS
-        This will return a hashtable of results 
+        This will return a hashtable of results
     #>
 
     [CmdletBinding()]
@@ -174,7 +174,7 @@ function Set-TargetResource
     .SYNOPSIS
         This will set the desired state
     #>
-    
+
     [CmdletBinding(SupportsShouldProcess = $true)]
     param
     (
@@ -182,147 +182,197 @@ function Set-TargetResource
         [ValidateLength(1, 64)]
         [String] $Name,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String] $Ensure = 'Present',
 
+        [Parameter()]
         [ValidateSet('Started', 'Stopped')]
         [String] $State,
 
+        [Parameter()]
         [Boolean] $autoStart,
 
+        [Parameter()]
         [String] $CLRConfigFile,
 
+        [Parameter()]
         [Boolean] $enable32BitAppOnWin64,
 
+        [Parameter()]
         [Boolean] $enableConfigurationOverride,
 
+        [Parameter()]
         [ValidateSet('Integrated', 'Classic')]
         [String] $managedPipelineMode,
 
+        [Parameter()]
         [String] $managedRuntimeLoader,
 
+        [Parameter()]
         [ValidateSet('v4.0', 'v2.0', '')]
         [String] $managedRuntimeVersion,
 
+        [Parameter()]
         [Boolean] $passAnonymousToken,
 
+        [Parameter()]
         [ValidateSet('OnDemand', 'AlwaysRunning')]
         [String] $startMode,
 
+        [Parameter()]
         [ValidateRange(10, 65535)]
         [UInt32] $queueLength,
 
+        [Parameter()]
         [ValidateSet('NoAction', 'KillW3wp', 'Throttle', 'ThrottleUnderLoad')]
         [String] $cpuAction,
 
+        [Parameter()]
         [ValidateRange(0, 100000)]
         [UInt32] $cpuLimit,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(0, 1440)]$valueInMinutes = [TimeSpan]::Parse($_).TotalMinutes); $?
         })]
         [String] $cpuResetInterval,
 
+        [Parameter()]
         [Boolean] $cpuSmpAffinitized,
 
+        [Parameter()]
         [UInt32] $cpuSmpProcessorAffinityMask,
 
+        [Parameter()]
         [UInt32] $cpuSmpProcessorAffinityMask2,
 
+        [Parameter()]
         [ValidateSet(
                 'ApplicationPoolIdentity', 'LocalService', 'LocalSystem',
                 'NetworkService', 'SpecificUser'
         )]
         [String] $identityType,
 
+        [Parameter()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()] 
+        [System.Management.Automation.Credential()]
         $Credential,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(0, 43200)]$valueInMinutes = [TimeSpan]::Parse($_).TotalMinutes); $?
         })]
         [String] $idleTimeout,
 
+        [Parameter()]
         [ValidateSet('Terminate', 'Suspend')]
         [String] $idleTimeoutAction,
 
+        [Parameter()]
         [Boolean] $loadUserProfile,
 
+        [Parameter()]
         [String] $logEventOnProcessModel,
 
+        [Parameter()]
         [ValidateSet('LogonBatch', 'LogonService')]
         [String] $logonType,
 
+        [Parameter()]
         [Boolean] $manualGroupMembership,
 
+        [Parameter()]
         [ValidateRange(0, 2147483647)]
         [UInt32] $maxProcesses,
 
+        [Parameter()]
         [Boolean] $pingingEnabled,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1, 4294967)]$valueInSeconds = [TimeSpan]::Parse($_).TotalSeconds); $?
         })]
         [String] $pingInterval,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1, 4294967)]$valueInSeconds = [TimeSpan]::Parse($_).TotalSeconds); $?
         })]
         [String] $pingResponseTime,
 
+        [Parameter()]
         [Boolean] $setProfileEnvironment,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1, 4294967)]$valueInSeconds = [TimeSpan]::Parse($_).TotalSeconds); $?
         })]
         [String] $shutdownTimeLimit,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1, 4294967)]$valueInSeconds = [TimeSpan]::Parse($_).TotalSeconds); $?
         })]
         [String] $startupTimeLimit,
 
+        [Parameter()]
         [String] $orphanActionExe,
 
+        [Parameter()]
         [String] $orphanActionParams,
 
+        [Parameter()]
         [Boolean] $orphanWorkerProcess,
 
+        [Parameter()]
         [ValidateSet('HttpLevel', 'TcpLevel')]
         [String] $loadBalancerCapabilities,
 
+        [Parameter()]
         [Boolean] $rapidFailProtection,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1, 144000)]$valueInMinutes = [TimeSpan]::Parse($_).TotalMinutes); $?
         })]
         [String] $rapidFailProtectionInterval,
 
+        [Parameter()]
         [ValidateRange(0, 2147483647)]
         [UInt32] $rapidFailProtectionMaxCrashes,
 
+        [Parameter()]
         [String] $autoShutdownExe,
 
+        [Parameter()]
         [String] $autoShutdownParams,
 
+        [Parameter()]
         [Boolean] $disallowOverlappingRotation,
 
+        [Parameter()]
         [Boolean] $disallowRotationOnConfigChange,
 
+        [Parameter()]
         [String] $logEventOnRecycle,
 
+        [Parameter()]
         [UInt32] $restartMemoryLimit,
 
+        [Parameter()]
         [UInt32] $restartPrivateMemoryLimit,
 
+        [Parameter()]
         [UInt32] $restartRequestsLimit,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(0, 432000)]$valueInMinutes = [TimeSpan]::Parse($_).TotalMinutes); $?
         })]
         [String] $restartTimeLimit,
 
+        [Parameter()]
         [ValidateScript({
             ($_ -eq '') -or
             (& {
@@ -369,7 +419,7 @@ function Set-TargetResource
                     $propertyPath = $_.Path
                     $property = Get-Property -Object $appPool -PropertyName $propertyPath
 
-                    if ( 
+                    if (
                         $PSBoundParameters[$propertyName] -ne $property
                     )
                     {
@@ -551,147 +601,197 @@ function Test-TargetResource
         [ValidateLength(1, 64)]
         [String] $Name,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String] $Ensure = 'Present',
 
+        [Parameter()]
         [ValidateSet('Started', 'Stopped')]
         [String] $State,
 
+        [Parameter()]
         [Boolean] $autoStart,
 
+        [Parameter()]
         [String] $CLRConfigFile,
 
+        [Parameter()]
         [Boolean] $enable32BitAppOnWin64,
 
+        [Parameter()]
         [Boolean] $enableConfigurationOverride,
 
+        [Parameter()]
         [ValidateSet('Integrated', 'Classic')]
         [String] $managedPipelineMode,
 
+        [Parameter()]
         [String] $managedRuntimeLoader,
 
+        [Parameter()]
         [ValidateSet('v4.0', 'v2.0', '')]
         [String] $managedRuntimeVersion,
 
+        [Parameter()]
         [Boolean] $passAnonymousToken,
 
+        [Parameter()]
         [ValidateSet('OnDemand', 'AlwaysRunning')]
         [String] $startMode,
 
+        [Parameter()]
         [ValidateRange(10, 65535)]
         [UInt32] $queueLength,
 
+        [Parameter()]
         [ValidateSet('NoAction', 'KillW3wp', 'Throttle', 'ThrottleUnderLoad')]
         [String] $cpuAction,
 
+        [Parameter()]
         [ValidateRange(0, 100000)]
         [UInt32] $cpuLimit,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(0, 1440)]$valueInMinutes = [TimeSpan]::Parse($_).TotalMinutes); $?
         })]
         [String] $cpuResetInterval,
 
+        [Parameter()]
         [Boolean] $cpuSmpAffinitized,
 
+        [Parameter()]
         [UInt32] $cpuSmpProcessorAffinityMask,
 
+        [Parameter()]
         [UInt32] $cpuSmpProcessorAffinityMask2,
 
+        [Parameter()]
         [ValidateSet(
                 'ApplicationPoolIdentity', 'LocalService', 'LocalSystem',
                 'NetworkService', 'SpecificUser'
         )]
         [String] $identityType,
 
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(0, 43200)]$valueInMinutes = [TimeSpan]::Parse($_).TotalMinutes); $?
         })]
         [String] $idleTimeout,
 
+        [Parameter()]
         [ValidateSet('Terminate', 'Suspend')]
         [String] $idleTimeoutAction,
 
+        [Parameter()]
         [Boolean] $loadUserProfile,
 
+        [Parameter()]
         [String] $logEventOnProcessModel,
 
+        [Parameter()]
         [ValidateSet('LogonBatch', 'LogonService')]
         [String] $logonType,
 
+        [Parameter()]
         [Boolean] $manualGroupMembership,
 
+        [Parameter()]
         [ValidateRange(0, 2147483647)]
         [UInt32] $maxProcesses,
 
+        [Parameter()]
         [Boolean] $pingingEnabled,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1, 4294967)]$valueInSeconds = [TimeSpan]::Parse($_).TotalSeconds); $?
         })]
         [String] $pingInterval,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1, 4294967)]$valueInSeconds = [TimeSpan]::Parse($_).TotalSeconds); $?
         })]
         [String] $pingResponseTime,
 
+        [Parameter()]
         [Boolean] $setProfileEnvironment,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1, 4294967)]$valueInSeconds = [TimeSpan]::Parse($_).TotalSeconds); $?
         })]
         [String] $shutdownTimeLimit,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1, 4294967)]$valueInSeconds = [TimeSpan]::Parse($_).TotalSeconds); $?
         })]
         [String] $startupTimeLimit,
 
+        [Parameter()]
         [String] $orphanActionExe,
 
+        [Parameter()]
         [String] $orphanActionParams,
 
+        [Parameter()]
         [Boolean] $orphanWorkerProcess,
 
+        [Parameter()]
         [ValidateSet('HttpLevel', 'TcpLevel')]
         [String] $loadBalancerCapabilities,
 
+        [Parameter()]
         [Boolean] $rapidFailProtection,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1, 144000)]$valueInMinutes = [TimeSpan]::Parse($_).TotalMinutes); $?
         })]
         [String] $rapidFailProtectionInterval,
 
+        [Parameter()]
         [ValidateRange(0, 2147483647)]
         [UInt32] $rapidFailProtectionMaxCrashes,
 
+        [Parameter()]
         [String] $autoShutdownExe,
 
+        [Parameter()]
         [String] $autoShutdownParams,
 
+        [Parameter()]
         [Boolean] $disallowOverlappingRotation,
 
+        [Parameter()]
         [Boolean] $disallowRotationOnConfigChange,
 
+        [Parameter()]
         [String] $logEventOnRecycle,
 
+        [Parameter()]
         [UInt32] $restartMemoryLimit,
 
+        [Parameter()]
         [UInt32] $restartPrivateMemoryLimit,
 
+        [Parameter()]
         [UInt32] $restartRequestsLimit,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(0, 432000)]$valueInMinutes = [TimeSpan]::Parse($_).TotalMinutes); $?
         })]
         [String] $restartTimeLimit,
 
+        [Parameter()]
         [ValidateScript({
             ($_ -eq '') -or
             (& {
@@ -858,11 +958,14 @@ function Test-TargetResource
 
 #region Helper Functions
 
-function Get-Property 
+function Get-Property
 {
-    param 
+    param
     (
+        [Parameter()]
         [object] $Object,
+
+        [Parameter()]
         [string] $PropertyName)
 
     $parts = $PropertyName.Split('.')
@@ -883,14 +986,14 @@ function Get-Property
     {
         return $value
     }
-} 
+}
 
 <#
     .SYNOPSIS
         Runs appcmd.exe - if there's an error then the application will terminate
-        
+
     .PARAMETER ArgumentList
-        Optional list of string arguments to be passed into appcmd.exe    
+        Optional list of string arguments to be passed into appcmd.exe
 
 #>
 function Invoke-AppCmd
@@ -898,17 +1001,18 @@ function Invoke-AppCmd
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [String[]] $ArgumentList
     )
 
-    <# 
+    <#
             This is a local preference for the function which will terminate
             the program if there's an error invoking appcmd.exe
     #>
     $ErrorActionPreference = 'Stop'
 
     $appcmdFilePath = "$env:SystemRoot\System32\inetsrv\appcmd.exe"
-    
+
     $appcmdResult = $(& $appcmdFilePath $ArgumentList)
     Write-Verbose -Message $($appcmdResult).ToString()
 

--- a/DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.psm1
+++ b/DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.psm1
@@ -17,7 +17,7 @@ function Get-TargetResource
 {
     <#
     .SYNOPSIS
-        This will return a hashtable of results 
+        This will return a hashtable of results
     #>
 
     [CmdletBinding()]
@@ -80,7 +80,7 @@ function Test-TargetResource
         This tests the desired state. If the state is not correct it will return $false.
         If the state is correct it will return $true
     #>
-    
+
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -107,7 +107,7 @@ function Test-TargetResource
     if (-not((Confirm-Value -Path '' `
                             -Name 'managedRuntimeVersion' `
                             -NewValue $ManagedRuntimeVersion)))
-    { 
+    {
         return $false
     }
 
@@ -115,9 +115,9 @@ function Test-TargetResource
                             -Name 'identityType' `
                             -NewValue $IdentityType)))
     {
-        return $false 
+        return $false
     }
-    
+
     return $true
 }
 
@@ -142,7 +142,7 @@ function Confirm-Value
         [System.String]
         $NewValue
     )
-    
+
     if (-not($NewValue))
     {
         # if no new value was specified, we assume this value is okay.
@@ -200,7 +200,7 @@ function Set-Value
             -Filter "system.applicationHost/applicationPools/applicationPoolDefaults$Path" `
             -Name $Name `
             -Value "$NewValue"
-        
+
         $relPath = $Path + '/' + $Name
         Write-Verbose($LocalizedData.SettingValue -f $relPath,$NewValue);
     }

--- a/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
+++ b/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
@@ -17,8 +17,8 @@ data LocalizedData
         VerboseSetTargetPreload                                = Updating Preload for Web application "{0}".
         VerboseSetTargetAutostart                              = Updating AutoStart for Web application "{0}".
         VerboseSetTargetIISAutoStartProviders                  = Updating AutoStartProviders for IIS.
-        VerboseSetTargetWebApplicationAutoStartProviders       = Updating AutoStartProviders for Web application "{0}". 
-        VerboseSetTargetEnabledProtocols                       = Updating EnabledProtocols for Web application "{0}". 
+        VerboseSetTargetWebApplicationAutoStartProviders       = Updating AutoStartProviders for Web application "{0}".
+        VerboseSetTargetEnabledProtocols                       = Updating EnabledProtocols for Web application "{0}".
         VerboseTestTargetFalseAbsent                           = Web application "{0}" is absent and should not absent.
         VerboseTestTargetFalsePresent                          = Web application $Name should be absent and is not absent.
         VerboseTestTargetFalsePhysicalPath                     = Physical path for web application "{0}" does not match desired state.
@@ -36,11 +36,10 @@ data LocalizedData
 
 <#
 .SYNOPSIS
-    This will return a hashtable of results 
+    This will return a hashtable of results
 #>
 function Get-TargetResource
 {
-
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -72,7 +71,7 @@ function Get-TargetResource
     }
 
     Write-Verbose -Message $LocalizedData.VerboseGetTargetResource
-    
+
     $returnValue = @{
         Website                  = $Website
         Name                     = $Name
@@ -97,7 +96,6 @@ function Get-TargetResource
     #>
 function Set-TargetResource
 {
-
     [CmdletBinding()]
     param
     (
@@ -113,28 +111,36 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [String] $PhysicalPath,
 
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [String] $Ensure = 'Present',
 
+        [Parameter()]
         [AllowEmptyString()]
         [ValidateSet('','Ssl','SslNegotiateCert','SslRequireCert','Ssl128')]
         [String[]]$SslFlags = '',
 
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance]
         $AuthenticationInfo,
 
+        [Parameter()]
         [Boolean]
         $PreloadEnabled,
-        
+
+        [Parameter()]
         [Boolean]
         $ServiceAutoStartEnabled,
 
+        [Parameter()]
         [String]
         $ServiceAutoStartProvider,
-        
+
+        [Parameter()]
         [String]
         $ApplicationType,
-        
+
+        [Parameter()]
         [ValidateSet('http','https','net.tcp','net.msmq','net.pipe')]
         [String[]] $EnabledProtocols
     )
@@ -149,7 +155,7 @@ function Set-TargetResource
             {
                 $AuthenticationInfo = Get-DefaultAuthenticationInfo
             }
- 
+
             if ($webApplication.count -eq 0)
             {
                 Write-Verbose -Message ($LocalizedData.VerboseSetTargetPresent -f $Name)
@@ -257,7 +263,7 @@ function Set-TargetResource
                                  -Value $ServiceAutoStartProvider `
                                  -ErrorAction Stop
             }
-            
+
             # Update EnabledProtocols if required
             if ($PSBoundParameters.ContainsKey('EnabledProtocols') -and `
             (-not(Confirm-UniqueEnabledProtocols `
@@ -305,28 +311,36 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [String] $PhysicalPath,
 
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [String] $Ensure = 'Present',
 
+        [Parameter()]
         [AllowEmptyString()]
         [ValidateSet('','Ssl','SslNegotiateCert','SslRequireCert','Ssl128')]
         [String[]]$SslFlags = '',
 
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance]
         $AuthenticationInfo,
 
+        [Parameter()]
         [Boolean]
         $preloadEnabled,
-        
+
+        [Parameter()]
         [Boolean]
         $serviceAutoStartEnabled,
 
+        [Parameter()]
         [String]
         $serviceAutoStartProvider,
-        
+
+        [Parameter()]
         [String]
         $ApplicationType,
-        
+
+        [Parameter()]
         [ValidateSet('http','https','net.tcp','net.msmq','net.pipe')]
         [String[]] $EnabledProtocols
     )
@@ -335,24 +349,24 @@ function Test-TargetResource
 
     $webApplication = Get-WebApplication -Site $Website -Name $Name
 
-    if ($AuthenticationInfo -eq $null) 
+    if ($AuthenticationInfo -eq $null)
     {
-        $AuthenticationInfo = Get-DefaultAuthenticationInfo 
+        $AuthenticationInfo = Get-DefaultAuthenticationInfo
     }
 
-    if ($webApplication.count -eq 0 -and $Ensure -eq 'Present') 
+    if ($webApplication.count -eq 0 -and $Ensure -eq 'Present')
     {
         Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalseAbsent -f $Name)
         return $false
     }
 
-    if ($webApplication.count -eq 1 -and $Ensure -eq 'Absent') 
+    if ($webApplication.count -eq 1 -and $Ensure -eq 'Absent')
     {
         Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalsePresent -f $Name)
         return $false
     }
 
-    if ($webApplication.count -eq 1 -and $Ensure -eq 'Present') 
+    if ($webApplication.count -eq 1 -and $Ensure -eq 'Present')
     {
         #Check Physical Path
         if ($webApplication.physicalPath -ne $PhysicalPath)
@@ -393,7 +407,7 @@ function Test-TargetResource
         {
             Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalsePreload -f $Name)
             return $false
-        } 
+        }
 
         #Check AutoStartEnabled
         if($PSBoundParameters.ContainsKey('ServiceAutoStartEnabled') -and `
@@ -403,7 +417,7 @@ function Test-TargetResource
             return $false
         }
 
-        #Check AutoStartProviders 
+        #Check AutoStartProviders
         if ($PSBoundParameters.ContainsKey('ServiceAutoStartProvider') -and `
             $webApplication.serviceAutoStartProvider -ne $ServiceAutoStartProvider)
         {
@@ -412,13 +426,13 @@ function Test-TargetResource
                         -ApplicationType $ApplicationType))
             {
                 Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalseIISAutoStartProviders)
-                return $false     
+                return $false
             }
             Write-Verbose -Message `
                 ($LocalizedData.VerboseTestTargetFalseWebApplicationAutoStartProviders -f $Name)
-            return $false      
+            return $false
         }
-        
+
         # Update EnabledProtocols if required
         if ($PSBoundParameters.ContainsKey('EnabledProtocols') -and `
             (-not(Confirm-UniqueEnabledProtocols `
@@ -431,9 +445,9 @@ function Test-TargetResource
         }
 
     }
-    
+
     return $true
-    
+
 }
 
 <#
@@ -445,7 +459,7 @@ function Test-TargetResource
 .PARAMETER ProposedProtocols
     Specifies desired SMTP bindings.
 .NOTES
-    ExistingProtocols is a String whereas ProposedProtocols is an array of Strings 
+    ExistingProtocols is a String whereas ProposedProtocols is an array of Strings
     so we need to do some extra work in comparing them
 #>
 function Confirm-UniqueEnabledProtocols
@@ -453,18 +467,18 @@ function Confirm-UniqueEnabledProtocols
     [CmdletBinding()]
     [OutputType([Boolean])]
     param
-    ( 
+    (
         [Parameter(Mandatory = $true)]
         [AllowEmptyString()]
         [String] $ExistingProtocols,
-        
+
         [Parameter(Mandatory = $true)]
         [String[]] $ProposedProtocols
     )
 
     $inputToCheck = @()
     foreach ($proposedProtocol in $ProposedProtocols)
-    { 
+    {
         $inputToCheck += $proposedProtocol
     }
 
@@ -494,15 +508,15 @@ function Confirm-UniqueEnabledProtocols
 
 <#
 .SYNOPSIS
-    Helper function used to validate that the AutoStartProviders is unique to other 
+    Helper function used to validate that the AutoStartProviders is unique to other
     websites. Returns False if the AutoStartProviders exist.
 .PARAMETER serviceAutoStartProvider
     Specifies the name of the AutoStartProviders.
 .PARAMETER ExcludeStopped
     Specifies the name of the Application Type for the AutoStartProvider.
 .NOTES
-    This tests for the existance of a AutoStartProviders which is globally assigned. 
-    As AutoStartProviders need to be uniquely named it will check for this and error out if 
+    This tests for the existance of a AutoStartProviders which is globally assigned.
+    As AutoStartProviders need to be uniquely named it will check for this and error out if
     attempting to add a duplicatly named AutoStartProvider.
     Name is passed in to bubble to any error messages during the test.
 #>
@@ -589,7 +603,7 @@ function Get-AuthenticationInfo
             -ClassName MSFT_xWebApplicationAuthenticationInformation `
             -ClientOnly -Property $authenticationProperties `
             -NameSpace 'root\microsoft\windows\desiredstateconfiguration'
-            
+
 }
 
 <#
@@ -626,7 +640,7 @@ function Get-SslFlags
                 -Filter 'system.webserver/security/access' | `
                  ForEach-Object { $_.sslFlags }
 
-    if ($null -eq $SslFlags) 
+    if ($null -eq $SslFlags)
     {
         return [String]::Empty
     }
@@ -642,7 +656,7 @@ function Get-SslFlags
 .PARAMETER Name
     Specifies the name of the Application.
 .PARAMETER Type
-    Specifies the type of Authentication, 
+    Specifies the type of Authentication,
 Limited to the set: ('Anonymous','Basic','Digest','Windows').
 .PARAMETER Enabled
     Whether the Authentication is enabled or not.
@@ -662,6 +676,7 @@ function Set-Authentication
         [ValidateSet('Anonymous','Basic','Digest','Windows')]
         [String] $Type,
 
+        [Parameter()]
         [Boolean] $Enabled
     )
 
@@ -669,7 +684,7 @@ function Set-Authentication
         -Filter /system.WebServer/security/authentication/${Type}Authentication `
         -Name enabled `
         -Value $Enabled `
-        -Location "${Site}/${Name}" 
+        -Location "${Site}/${Name}"
 }
 
 <#
@@ -710,14 +725,14 @@ function Set-AuthenticationInfo
 
 <#
 .SYNOPSIS
-    Helper function used to test the authenticationProperties state for an Application. 
+    Helper function used to test the authenticationProperties state for an Application.
     Will return that value which will either [String]True or [String]False
 .PARAMETER Site
     Specifies the name of the Website.
 .PARAMETER Name
     Specifies the name of the Application.
 .PARAMETER Type
-    Specifies the type of Authentication, 
+    Specifies the type of Authentication,
     limited to the set: ('Anonymous','Basic','Digest','Windows').
 #>
 
@@ -745,15 +760,15 @@ function Test-AuthenticationEnabled
             -Location "${Site}/${Name}"
 
     return $prop.Value
-    
+
 }
 
 <#
 .SYNOPSIS
-    Helper function used to test the authenticationProperties state for an Application. 
-    Will return that result which will either [boolean]$True or [boolean]$False for use in 
+    Helper function used to test the authenticationProperties state for an Application.
+    Will return that result which will either [boolean]$True or [boolean]$False for use in
     Test-TargetResource.
-    Uses Test-AuthenticationEnabled to determine this. First incorrect result will break 
+    Uses Test-AuthenticationEnabled to determine this. First incorrect result will break
     this function out.
 .PARAMETER Site
     Specifies the name of the Website.
@@ -782,7 +797,6 @@ function Test-AuthenticationInfo
 
     foreach ($type in @('Anonymous', 'Basic', 'Digest', 'Windows'))
     {
-
         $expected = $AuthenticationInfo.CimInstanceProperties[$type].Value
         $actual = Test-AuthenticationEnabled -Site $Site `
                                              -Name $Name `
@@ -794,12 +808,12 @@ function Test-AuthenticationInfo
     }
 
     return $true
-    
+
 }
 
 <#
 .SYNOPSIS
-    Helper function used to test the SSLFlags on an Application. 
+    Helper function used to test the SSLFlags on an Application.
     Will return $true if they match and $false if they do not.
 .PARAMETER SslFlags
     Specifies the SslFlags to Test
@@ -812,6 +826,7 @@ function Test-SslFlags
     [OutputType([Boolean])]
     param
     (
+        [Parameter()]
         [AllowEmptyString()]
         [ValidateSet('','Ssl','SslNegotiateCert','SslRequireCert','Ssl128')]
         [String[]] $SslFlags = '',

--- a/DSCResources/MSFT_xWebConfigKeyValue/MSFT_xWebConfigKeyValue.psm1
+++ b/DSCResources/MSFT_xWebConfigKeyValue/MSFT_xWebConfigKeyValue.psm1
@@ -28,14 +28,14 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String] $WebsitePath,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('AppSettings')]
         [System.String] $ConfigSection,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [String] $Key
     )
 
@@ -91,21 +91,24 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String] $WebsitePath,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('AppSettings')]
         [System.String] $ConfigSection,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [String] $Key,
 
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [System.String] $Ensure = 'Present',
 
+        [Parameter()]
         [String] $Value,
 
+        [Parameter()]
         [System.Boolean] $IsAttribute
     )
 
@@ -177,21 +180,24 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String] $WebsitePath,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('AppSettings')]
         [System.String] $ConfigSection,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [String] $Key,
 
+        [Parameter()]
         [String] $Value,
 
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [System.String] $Ensure = 'Present',
 
+        [Parameter()]
         [System.Boolean] $IsAttribute
     )
 
@@ -242,14 +248,19 @@ function Add-Item
 {
     param
     (
+        [Parameter()]
         [string] $Key,
 
+        [Parameter()]
         [string] $Value,
 
+        [Parameter()]
         [Boolean] $isAttribute,
 
+        [Parameter()]
         [string] $WebsitePath,
 
+        [Parameter()]
         [string] $ConfigSection
     )
 
@@ -281,16 +292,22 @@ function Edit-Item
 {
     param
     (
-        [string] $PropertyName,        
+        [Parameter()]
+        [string] $PropertyName,
 
+        [Parameter()]
         [string] $OldValue,
 
+        [Parameter()]
         [string] $NewValue,
 
+        [Parameter()]
         [Boolean] $IsAttribute,
 
+        [Parameter()]
         [string] $WebsitePath,
 
+        [Parameter()]
         [string] $ConfigSection
     )
 
@@ -319,12 +336,16 @@ function Remove-Item
 {
     param
     (
+        [Parameter()]
         [string] $Key,
 
+        [Parameter()]
         [Boolean] $IsAttribute,
 
+        [Parameter()]
         [string] $WebsitePath,
 
+        [Parameter()]
         [string] $ConfigSection
     )
 
@@ -370,13 +391,17 @@ function Get-ItemValue
 {
     param
     (
+        [Parameter()]
         [string] $Key,
 
+        [Parameter()]
         [Boolean] $isAttribute,
 
+        [Parameter()]
         [string] $WebsitePath,
 
         # If this is null $value.Value will be null
+        [Parameter()]
         [string] $ConfigSection
     )
 

--- a/DSCResources/MSFT_xWebSiteDefaults/MSFT_xWebSiteDefaults.psm1
+++ b/DSCResources/MSFT_xWebSiteDefaults/MSFT_xWebSiteDefaults.psm1
@@ -16,23 +16,23 @@ function Get-TargetResource
 {
     <#
     .SYNOPSIS
-        This will return a hashtable of results 
+        This will return a hashtable of results
     #>
-    
+
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Machine')]
         [String]
         $ApplyTo
     )
-    
+
     Assert-Module
 
     Write-Verbose -Message $LocalizedData.VerboseGetTargetResource
-    
+
     return @{
         LogFormat              = (Get-Value 'siteDefaults/logFile' 'logFormat')
         TraceLogDirectory      = ( Get-Value 'siteDefaults/traceFailedRequestsLogging' 'directory')
@@ -40,7 +40,7 @@ function Get-TargetResource
         AllowSubDirConfig      = (Get-Value 'virtualDirectoryDefaults' 'allowSubDirConfig')
         ApplyTo                = 'Machine'
         LogDirectory           = (Get-Value 'siteDefaults/logFile' 'directory')
-    }    
+    }
 
 }
 
@@ -49,7 +49,7 @@ function Set-TargetResource
     <#
     .SYNOPSIS
         This will set the desired state
-    
+
     .NOTES
         Only a limited number of settings are supported at this time
         We try to cover the most common use cases
@@ -59,31 +59,36 @@ function Set-TargetResource
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     param
-    (    
-        [ValidateSet('Machine')]
+    (
         [Parameter(Mandatory = $true)]
+        [ValidateSet('Machine')]
         [String] $ApplyTo,
-        
+
+        [Parameter()]
         [ValidateSet('W3C','IIS','NCSA','Custom')]
         [String] $LogFormat,
-        
+
+        [Parameter()]
         [String] $LogDirectory,
-        
+
+        [Parameter()]
         [String] $TraceLogDirectory,
-        
+
+        [Parameter()]
         [String] $DefaultApplicationPool,
-        
+
+        [Parameter()]
         [ValidateSet('true','false')]
         [String] $AllowSubDirConfig
     )
 
     Assert-Module
 
-    Set-Value 'siteDefaults/logFile' 'logFormat' $LogFormat
-    Set-Value 'siteDefaults/logFile' 'directory' $LogDirectory
-    Set-Value 'siteDefaults/traceFailedRequestsLogging' 'directory' $TraceLogDirectory
-    Set-Value 'applicationDefaults' 'applicationPool' $DefaultApplicationPool
-    Set-Value 'virtualDirectoryDefaults' 'allowSubDirConfig' $AllowSubDirConfig
+    Set-Value -Path 'siteDefaults/logFile' -Name 'logFormat' -NewValue $LogFormat
+    Set-Value -Path 'siteDefaults/logFile' -Name 'directory' -NewValue $LogDirectory
+    Set-Value -Path 'siteDefaults/traceFailedRequestsLogging' -Name 'directory' -NewValue $TraceLogDirectory
+    Set-Value -Path 'applicationDefaults' -Name 'applicationPool' -NewValue $DefaultApplicationPool
+    Set-Value -Path 'virtualDirectoryDefaults' -Name 'allowSubDirConfig' -NewValue $AllowSubDirConfig
 
 }
 
@@ -94,24 +99,29 @@ function Test-TargetResource
         This tests the desired state. If the state is not correct it will return $false.
         If the state is correct it will return $true
     #>
-    
+
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [OutputType([System.Boolean])]
     param
-    (    
-        [ValidateSet('Machine')]
+    (
         [Parameter(Mandatory = $true)]
+        [ValidateSet('Machine')]
         [String] $ApplyTo,
-        
+
+        [Parameter()]
         [ValidateSet('W3C','IIS','NCSA','Custom')]
         [String] $LogFormat,
-        
+
+        [Parameter()]
         [String] $LogDirectory,
-        
+
+        [Parameter()]
         [String] $TraceLogDirectory,
-        
+
+        [Parameter()]
         [String] $DefaultApplicationPool,
-        
+
+        [Parameter()]
         [ValidateSet('true','false')]
         [String] $AllowSubDirConfig
     )
@@ -122,37 +132,37 @@ function Test-TargetResource
 
     if (-not(Confirm-Value -Path 'virtualDirectoryDefaults' `
                            -Name 'allowSubDirConfig' `
-                           -NewValue $AllowSubDirConfig)) 
-    { 
-        return $false 
+                           -NewValue $AllowSubDirConfig))
+    {
+        return $false
     }
 
     if (-not(Confirm-Value -Path 'siteDefaults/logFile' `
                            -Name 'logFormat' `
-                           -NewValue $LogFormat)) 
-    { 
-        return $false 
+                           -NewValue $LogFormat))
+    {
+        return $false
     }
 
     if (-not(Confirm-Value -Path 'siteDefaults/logFile' `
                            -Name 'directory' `
-                           -NewValue $LogDirectory)) 
-    { 
-        return $false 
+                           -NewValue $LogDirectory))
+    {
+        return $false
     }
 
     if (-not(Confirm-Value -Path 'siteDefaults/traceFailedRequestsLogging' `
                            -Name 'directory' `
-                           -NewValue $TraceLogDirectory)) 
-    { 
-        return $false 
+                           -NewValue $TraceLogDirectory))
+    {
+        return $false
     }
 
     if (-not(Confirm-Value -Path 'applicationDefaults' `
                            -Name 'applicationPool' `
-                           -NewValue $DefaultApplicationPool)) 
-    { 
-        return $false 
+                           -NewValue $DefaultApplicationPool))
+    {
+        return $false
     }
 
     return $true
@@ -167,13 +177,16 @@ function Confirm-Value
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [String] $Path,
 
+        [Parameter()]
         [String] $Name,
-        
+
+        [Parameter()]
         [String] $NewValue
     )
-    
+
     if (-not($NewValue))
     {
         return $true
@@ -189,7 +202,7 @@ function Confirm-Value
         $relPath = $Path + '/' + $Name
         Write-Verbose($LocalizedData.ValueOk -f $relPath,$NewValue);
         return $true
-    }   
+    }
 
 }
 
@@ -198,10 +211,13 @@ function Set-Value
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [String] $Path,
 
+        [Parameter()]
         [String] $Name,
-        
+
+        [Parameter()]
         [String] $NewValue
     )
 
@@ -221,7 +237,7 @@ function Set-Value
                                      -Value "$NewValue"
         $relPath = $Path + '/' + $Name
         Write-Verbose($LocalizedData.SettingValue -f $relPath,$NewValue);
-    }    
+    }
 
 }
 
@@ -230,8 +246,10 @@ function Get-Value
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [String] $Path,
 
+        [Parameter()]
         [String] $Name
     )
 

--- a/DSCResources/MSFT_xWebVirtualDirectory/MSFT_xWebVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xWebVirtualDirectory/MSFT_xWebVirtualDirectory.psm1
@@ -20,7 +20,7 @@ function Get-TargetResource
 {
     <#
     .SYNOPSIS
-        This will return a hashtable of results 
+        This will return a hashtable of results
     #>
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
@@ -81,6 +81,7 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [System.String]
         $Ensure = 'Present',
@@ -157,6 +158,7 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
+        [Parameter()]
         [ValidateSet('Present','Absent')]
         [System.String]
         $Ensure = 'Present',

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -99,7 +99,6 @@ data LocalizedData
 #>
 function Get-TargetResource
 {
-
     [CmdletBinding()]
     [OutputType([Hashtable])]
     param
@@ -191,6 +190,7 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present',
@@ -205,70 +205,89 @@ function Set-TargetResource
         [UInt32]
         $SiteId,
 
+        [Parameter()]
         [String]
         $PhysicalPath,
 
+        [Parameter()]
         [ValidateSet('Started', 'Stopped')]
         [String]
         $State = 'Started',
 
         # The application pool name must contain between 1 and 64 characters
+        [Parameter()]
         [ValidateLength(1, 64)]
         [String]
         $ApplicationPool,
 
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $BindingInfo,
 
+        [Parameter()]
         [String[]]
         $DefaultPage,
 
+        [Parameter()]
         [String]
         $EnabledProtocols,
 
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance]
         $AuthenticationInfo,
 
+        [Parameter()]
         [Boolean]
         $PreloadEnabled,
 
+        [Parameter()]
         [Boolean]
         $ServiceAutoStartEnabled,
 
+        [Parameter()]
         [String]
         $ServiceAutoStartProvider,
 
+        [Parameter()]
         [String]
         $ApplicationType,
 
+        [Parameter()]
         [String]
         $LogPath,
 
+        [Parameter()]
         [ValidateSet('Date','Time','ClientIP','UserName','SiteName','ComputerName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','BytesSent','BytesRecv','TimeTaken','ServerPort','UserAgent','Cookie','Referer','ProtocolVersion','Host','HttpSubStatus')]
         [String[]]
         $LogFlags,
 
+        [Parameter()]
         [ValidateSet('Hourly','Daily','Weekly','Monthly','MaxSize')]
         [String]
         $LogPeriod,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1048576, 4294967295)] $valueAsUInt64 = [UInt64]::Parse($_))
         })]
         [String]
         $LogTruncateSize,
 
+        [Parameter()]
         [Boolean]
         $LoglocalTimeRollover,
 
+        [Parameter()]
         [ValidateSet('IIS','W3C','NCSA')]
         [String]
         $LogFormat,
 
+        [Parameter()]
         [ValidateSet('File','ETW','File,ETW')]
         [String]
         $LogTargetW3C,
 
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $LogCustomFields
     )
@@ -418,7 +437,8 @@ function Set-TargetResource
                 }
 
                 # New-WebSite has Id parameter instead of SiteId, so it's getting mapped to Id
-                if ($PSBoundParameters.ContainsKey('SiteId')) {
+                if ($PSBoundParameters.ContainsKey('SiteId'))
+                {
                     $newWebsiteSplat.Add('Id', $SiteId)
                 } elseif (-not (Get-WebSite)) {
                     # If there are no other websites and SiteId is missing, specify the Id Parameter for the new website.
@@ -426,7 +446,8 @@ function Set-TargetResource
                     $newWebsiteSplat.Add('Id', 1)
                 }
 
-                if ([String]::IsNullOrEmpty($PhysicalPath)) {
+                if ([String]::IsNullOrEmpty($PhysicalPath))
+                {
                     # If no physical path is provided run New-Website with -Force flag
                     $website = New-Website @newWebsiteSplat -ErrorAction Stop -Force
                 } else {
@@ -710,6 +731,7 @@ function Test-TargetResource
     [OutputType([Boolean])]
     param
     (
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present',
@@ -723,70 +745,89 @@ function Test-TargetResource
         [UInt32]
         $SiteId,
 
+        [Parameter()]
         [String]
         $PhysicalPath,
 
+        [Parameter()]
         [ValidateSet('Started', 'Stopped')]
         [String]
         $State = 'Started',
 
         # The application pool name must contain between 1 and 64 characters
+        [Parameter()]
         [ValidateLength(1, 64)]
         [String]
         $ApplicationPool,
 
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $BindingInfo,
 
+        [Parameter()]
         [String[]]
         $DefaultPage,
 
+        [Parameter()]
         [String]
         $EnabledProtocols,
 
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance]
         $AuthenticationInfo,
 
+        [Parameter()]
         [Boolean]
         $PreloadEnabled,
 
+        [Parameter()]
         [Boolean]
         $ServiceAutoStartEnabled,
 
+        [Parameter()]
         [String]
         $ServiceAutoStartProvider,
 
+        [Parameter()]
         [String]
         $ApplicationType,
 
+        [Parameter()]
         [String]
         $LogPath,
 
+        [Parameter()]
         [ValidateSet('Date','Time','ClientIP','UserName','SiteName','ComputerName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','BytesSent','BytesRecv','TimeTaken','ServerPort','UserAgent','Cookie','Referer','ProtocolVersion','Host','HttpSubStatus')]
         [String[]]
         $LogFlags,
 
+        [Parameter()]
         [ValidateSet('Hourly','Daily','Weekly','Monthly','MaxSize')]
         [String]
         $LogPeriod,
 
+        [Parameter()]
         [ValidateScript({
             ([ValidateRange(1048576, 4294967295)] $valueAsUInt64 = [UInt64]::Parse($_))
         })]
         [String]
         $LogTruncateSize,
 
+        [Parameter()]
         [Boolean]
         $LoglocalTimeRollover,
 
+        [Parameter()]
         [ValidateSet('IIS','W3C','NCSA')]
         [String]
         $LogFormat,
 
+        [Parameter()]
         [ValidateSet('File','ETW','File,ETW')]
         [String]
         $LogTargetW3C,
 
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $LogCustomFields
     )
@@ -1106,7 +1147,7 @@ function Confirm-UniqueBinding
         [String]
         $Name,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Switch]
         $ExcludeStopped
     )
@@ -1708,6 +1749,7 @@ function Set-Authentication
         [ValidateSet('Anonymous','Basic','Digest','Windows')]
         [String]$Type,
 
+        [Parameter()]
         [Boolean]$Enabled
     )
 
@@ -2147,7 +2189,7 @@ function Update-WebsiteBinding
         [String]
         $Name,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $BindingInfo
     )

--- a/README.md
+++ b/README.md
@@ -328,6 +328,9 @@ This resource manages the IIS configuration section locking (overrideMode) to co
     * Common Tests - Validate Module Files
     * Common Tests - Validate Markdown Files
     * Common Tests - Validate Markdown Links
+    * Common Tests - Custom Script Analyzer Rules
+    * Common Tests - Flagged Script Analyzer Rules
+    * Common Tests - Required Script Analyzer Rules
   * Add ConfigurationPath to xIisMimeTypeMapping examples since it is now a required field.
 
 ### 2.6.0.0


### PR DESCRIPTION
#### Pull Request (PR) description

This PR opts in to the following DSC Resource Script Analyzer meta tests:

- Common Tests - Custom Script Analyzer Rules
- Common Tests - Flagged Script Analyzer Rules
- Common Tests - Required Script Analyzer Rules

To pass these tests the following files have been modified:

- DSCResources/Helper.psm1
- DSCResources/MSFT_xIIsHandler/MSFT_xIisHandler.psm1
- DSCResources/MSFT_xIisFeatureDelegation/MSFT_xIisFeatureDelegation.psm1
- DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
- DSCResources/MSFT_xIisModule/MSFT_xIisModule.psm1
- DSCResources/MSFT_xSSLSettings/MSFT_xSSLSettings.psm1
- DSCResources/MSFT_xWebAppPool/MSFT_xWebAppPool.psm1
- DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.psm1
- DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.psm1
- DSCResources/MSFT_xWebConfigKeyValue/MSFT_xWebConfigKeyValue.psm1
- DSCResources/MSFT_xWebSiteDefaults/MSFT_xWebSiteDefaults.psm1
- DSCResources/MSFT_xWebVirtualDirectory/MSFT_xWebVirtualDirectory.psm1
- DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1

The tests that have been fixed are:

- DscResource.AnalyzerRules\Measure-ParameterBlockMandatoryNamedArgument
- DscResource.AnalyzerRules\Measure-ParameterBlockParameterAttribute
- DscResource.AnalyzerRules\Measure-ForEachStatement
- DscResource.AnalyzerRules\Measure-FunctionBlockBraces
- PSDSCUseVerboseMessageInDSCResource
- PSAvoidUsingPositionalParameters

This helps move the module towards passing the HQRM requirements.

#### This Pull Request (PR) fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/432)
<!-- Reviewable:end -->
