### PR TITLE
xWebAppPool: Correctly compare comma-separated String memberships

### DIFF
--- a/DSCResources/MSFT_xWebAppPool/MSFT_xWebAppPool.psm1
+++ b/DSCResources/MSFT_xWebAppPool/MSFT_xWebAppPool.psm1
@@ -94,6 +94,11 @@ data PropertyData
     )
 }
 
+# Properties that are specified as a single comma-separated string containing multiple flags
+$CommaSeparatedStringProperties = @(
+    'logEventOnRecycle'
+)
+
 function Get-TargetResource
 {
     <#
@@ -842,9 +847,9 @@ function Test-TargetResource
                 $propertyPath = $_.Path
                 $property = Get-Property -Object $appPool -PropertyName $propertyPath
 
-                # First check if the property is a comma-separated array as a String, split and compare membership if so
+                # First check if the property is a single comma-separated string containing multiple flags, split and compare membership if so
                 if (
-                    ($property.GetType().FullName -eq 'System.String') -and ($property.Contains(','))
+                    $propertyName -in $CommaSeparatedStringProperties
                 )
                 {
                     $currentPropertyCollection = $property.Split(',')

--- a/DSCResources/MSFT_xWebAppPool/MSFT_xWebAppPool.psm1
+++ b/DSCResources/MSFT_xWebAppPool/MSFT_xWebAppPool.psm1
@@ -842,7 +842,25 @@ function Test-TargetResource
                 $propertyPath = $_.Path
                 $property = Get-Property -Object $appPool -PropertyName $propertyPath
 
+                # First check if the property is a comma-separated array as a String, split and compare membership if so
                 if (
+                    ($property.GetType().FullName -eq 'System.String') -and ($property.Contains(','))
+                )
+                {
+                    $currentPropertyCollection = $property.Split(',')
+                    $expectedPropertyCollection = $PSBoundParameters[$propertyName].Split(',')
+
+                    $compareResult = @(Compare-Object -ReferenceObject $currentPropertyCollection -DifferenceObject $expectedPropertyCollection)
+                    if ($compareResult.Length -ne 0)
+                    {
+                        Write-Verbose -Message (
+                            $LocalizedData['VerbosePropertyNotInDesiredState'] -f $propertyName, $Name
+                        )
+
+                        $inDesiredState = $false
+                    }
+                }
+                elseif (
                     $PSBoundParameters[$propertyName] -ne $property
                 )
                 {

--- a/DSCResources/MSFT_xWebAppPool/MSFT_xWebAppPool.psm1
+++ b/DSCResources/MSFT_xWebAppPool/MSFT_xWebAppPool.psm1
@@ -95,7 +95,7 @@ data PropertyData
 }
 
 # Properties that are specified as a single comma-separated string containing multiple flags
-$CommaSeparatedStringProperties = @(
+$script:commaSeparatedStringProperties = @(
     'logEventOnRecycle'
 )
 
@@ -848,9 +848,7 @@ function Test-TargetResource
                 $property = Get-Property -Object $appPool -PropertyName $propertyPath
 
                 # First check if the property is a single comma-separated string containing multiple flags, split and compare membership if so
-                if (
-                    $propertyName -in $CommaSeparatedStringProperties
-                )
+                if ($propertyName -in $script:commaSeparatedStringProperties)
                 {
                     $currentPropertyCollection = $property.Split(',')
                     $expectedPropertyCollection = $PSBoundParameters[$propertyName].Split(',')

--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ This resource manages the IIS configuration section locking (overrideMode) to co
   * Added ServerAutoStart (controls website autostart) and changed documentation for ServiceAutoStartEnabled (controls application auto-initialization). Fixes #325.
   * Fix multiple HTTPS bindings on one xWebsite receiving the first binding's certificate [#332](https://github.com/PowerShell/xWebAdministration/issues/332)
     * Added unit regression test
+* Changes to xWebAppPool
+  * Fix false `Test-TargetResource` failure for `logEventOnRecycle` if items in the Configuration property are specified in a different order than IIS natively stores them [#434](https://github.com/PowerShell/xWebAdministration/issues/434)
 
 ### 2.7.0.0
 

--- a/Tests/Unit/MSFT_xWebAppPool.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebAppPool.Tests.ps1
@@ -1563,6 +1563,11 @@ try
                     Should Be $true
                 }
 
+                It 'Should return True when the property matches the desired state but items are in a different order' {
+                    Test-TargetResource -Ensure 'Present' -Name $mockAppPool.name -logEventOnRecycle 'IsapiUnhealthy,OnDemand,ConfigChange,PrivateMemory,Time,Requests,Schedule,Memory' |
+                    Should Be $true
+                }
+
                 It 'Should return False when the property does not match the desired state' {
                     Test-TargetResource -Ensure 'Present' -Name $mockAppPool.name -logEventOnRecycle 'Time,Memory,PrivateMemory' |
                     Should Be $false


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
If a String property is actually a comma-separated array, split the string on commas and compare membership between the current and expected values. This avoids false `Test-TargetResource` failures when comparing properties that are Strings, should really be collections of Strings, and have items in different order.

#### This Pull Request (PR) fixes the following issues
- Fixes #434 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/439)
<!-- Reviewable:end -->
