### PR TITLE
xWebsite/xIISLogging: Get-TargetResource returns expected array of individual log flags instead of a single comma-separated string

### DIFF
--- a/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
+++ b/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
@@ -51,9 +51,18 @@ function Get-TargetResource
 
     $cimLogCustomFields = @(ConvertTo-CimLogCustomFields -InputObject $currentLogSettings.logFile.customFields.Collection)
 
+    if ($currentLogSettings.LogExtFileFlags -is [System.String])
+    {
+        $logFlagsArray = [System.String[]]$currentLogSettings.LogExtFileFlags.Split(',')
+    }
+    else
+    {
+        $logFlagsArray = [System.String[]]@()
+    }
+
     return @{
         LogPath              = $currentLogSettings.directory
-        LogFlags             = [Array]$currentLogSettings.LogExtFileFlags
+        LogFlags             = $logFlagsArray
         LogPeriod            = $currentLogSettings.period
         LogTruncateSize      = $currentLogSettings.truncateSize
         LoglocalTimeRollover = $currentLogSettings.localTimeRollover

--- a/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
+++ b/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
@@ -51,13 +51,10 @@ function Get-TargetResource
 
     $cimLogCustomFields = @(ConvertTo-CimLogCustomFields -InputObject $currentLogSettings.logFile.customFields.Collection)
 
+    $logFlagsArray = $null
     if ($currentLogSettings.LogExtFileFlags -is [System.String])
     {
         $logFlagsArray = [System.String[]]$currentLogSettings.LogExtFileFlags.Split(',')
-    }
-    else
-    {
-        $logFlagsArray = $currentLogSettings.LogExtFileFlags
     }
 
     return @{

--- a/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
+++ b/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
@@ -57,7 +57,7 @@ function Get-TargetResource
     }
     else
     {
-        $logFlagsArray = [System.String[]]@()
+        $logFlagsArray = $currentLogSettings.LogExtFileFlags
     }
 
     return @{

--- a/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
+++ b/DSCResources/MSFT_xIisLogging/MSFT_xIisLogging.psm1
@@ -54,7 +54,7 @@ function Get-TargetResource
     $logFlagsArray = $null
     if ($currentLogSettings.LogExtFileFlags -is [System.String])
     {
-        $logFlagsArray = [System.String[]]$currentLogSettings.LogExtFileFlags.Split(',')
+        $logFlagsArray = [System.String[]] $currentLogSettings.LogExtFileFlags.Split(',')
     }
 
     return @{

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -142,7 +142,7 @@ function Get-TargetResource
         $logFlagsArray = $null
         if ($website.logfile.LogExtFileFlags -is [System.String])
         {
-            $logFlagsArray = [System.String[]]$website.logfile.LogExtFileFlags.Split(',')
+            $logFlagsArray = [System.String[]] $website.logfile.LogExtFileFlags.Split(',')
         }
     }
     # Multiple websites with the same name exist. This is not supported and is an error

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -138,6 +138,15 @@ function Get-TargetResource
                                 Select-Object Name,Type
 
         [Array] $cimLogCustomFields = ConvertTo-CimLogCustomFields -InputObject $website.logFile.customFields.Collection
+
+        if ($website.logfile.LogExtFileFlags -is [System.String])
+        {
+            $logFlagsArray = [System.String[]]$website.logfile.LogExtFileFlags.Split(',')
+        }
+        else
+        {
+            $logFlagsArray = [System.String[]]@()
+        }
     }
     # Multiple websites with the same name exist. This is not supported and is an error
     else
@@ -166,7 +175,7 @@ function Get-TargetResource
         ServiceAutoStartEnabled  = $website.applicationDefaults.serviceAutoStartEnabled
         ApplicationType          = $webConfiguration.Type
         LogPath                  = $website.logfile.directory
-        LogFlags                 = [Array]$website.logfile.LogExtFileFlags
+        LogFlags                 = $logFlagsArray
         LogPeriod                = $website.logfile.period
         LogtruncateSize          = $website.logfile.truncateSize
         LoglocalTimeRollover     = $website.logfile.localTimeRollover

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -145,7 +145,7 @@ function Get-TargetResource
         }
         else
         {
-            $logFlagsArray = [System.String[]]@()
+            $logFlagsArray = $website.logfile.LogExtFileFlags
         }
     }
     # Multiple websites with the same name exist. This is not supported and is an error

--- a/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
+++ b/DSCResources/MSFT_xWebsite/MSFT_xWebsite.psm1
@@ -139,13 +139,10 @@ function Get-TargetResource
 
         [Array] $cimLogCustomFields = ConvertTo-CimLogCustomFields -InputObject $website.logFile.customFields.Collection
 
+        $logFlagsArray = $null
         if ($website.logfile.LogExtFileFlags -is [System.String])
         {
             $logFlagsArray = [System.String[]]$website.logfile.LogExtFileFlags.Split(',')
-        }
-        else
-        {
-            $logFlagsArray = $website.logfile.LogExtFileFlags
         }
     }
     # Multiple websites with the same name exist. This is not supported and is an error

--- a/README.md
+++ b/README.md
@@ -324,6 +324,14 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 
 * Changes to xWebAdministration
   * Resolved custom Script Analyzer rules that was added to the test framework.
+* Changes to xWebsite
+  * Fix `Get-TargetResource` so that `LogFlags` are returned as expected
+    array of strings (one for each flag) rather than an array containing
+    a single comma-separated string of flags' ([issue #332](https://github.com/PowerShell/xWebAdministration/issues/332)).
+* Changes to xIISLogging
+  * Fix `Get-TargetResource` so that `LogFlags` are returned as expected
+  array of strings (one for each flag) rather than an array containing a
+  single comma-separated string of flags ([issue #332](https://github.com/PowerShell/xWebAdministration/issues/332)).
 
 ### 2.8.0.0
 
@@ -333,13 +341,10 @@ This resource manages the IIS configuration section locking (overrideMode) to co
   * Added ServerAutoStart (controls website autostart) and changed documentation for ServiceAutoStartEnabled (controls application auto-initialization). Fixes #325.
   * Fix multiple HTTPS bindings on one xWebsite receiving the first binding's certificate [#332](https://github.com/PowerShell/xWebAdministration/issues/332)
     * Added unit regression test
-  * Fix `Get-TargetResource` so that `LogFlags` are returned as expected array of strings (one for each flag) rather than an array containing a single comma-separated string of flags
 * Changes to xWebAppPool
   * Fix false `Test-TargetResource` failure for `logEventOnRecycle` if items in the Configuration property are specified in a different order than IIS natively stores them [#434](https://github.com/PowerShell/xWebAdministration/issues/434)
 * Changes to xIisModule
   * Fixed the parameters specification for the internal Get-IISHandler and Remove-IISHandler function
-* Changes to xIISLogging
-  * Fix `Get-TargetResource` so that `LogFlags` are returned as expected array of strings (one for each flag) rather than an array containing a single comma-separated string of flags
 
 ### 2.7.0.0
 

--- a/README.md
+++ b/README.md
@@ -328,10 +328,13 @@ This resource manages the IIS configuration section locking (overrideMode) to co
   * Added ServerAutoStart (controls website autostart) and changed documentation for ServiceAutoStartEnabled (controls application auto-initialization). Fixes #325.
   * Fix multiple HTTPS bindings on one xWebsite receiving the first binding's certificate [#332](https://github.com/PowerShell/xWebAdministration/issues/332)
     * Added unit regression test
+  * Fix `Get-TargetResource` so that `LogFlags` are returned as expected array of strings (one for each flag) rather than an array containing a single comma-separated string of flags
 * Changes to xWebAppPool
   * Fix false `Test-TargetResource` failure for `logEventOnRecycle` if items in the Configuration property are specified in a different order than IIS natively stores them [#434](https://github.com/PowerShell/xWebAdministration/issues/434)
 * Changes to xIisModule
   * Fixed the parameters specification for the internal Get-IISHandler and Remove-IISHandler function
+* Changes to xIISLogging
+  * Fix `Get-TargetResource` so that `LogFlags` are returned as expected array of strings (one for each flag) rather than an array containing a single comma-separated string of flags
 
 ### 2.7.0.0
 

--- a/Tests/Unit/MSFT_xIISLogging.Tests.ps1
+++ b/Tests/Unit/MSFT_xIISLogging.Tests.ps1
@@ -67,6 +67,8 @@ try
                 customFields      = @{Collection = @($MockLogCustomFields)}
             }
 
+        $MockLogFlagsAfterSplit = [System.String[]]@('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
+
         Describe "$script:DSCResourceName\Assert-Module" {
 
             Context 'WebAdminstration module is not installed' {
@@ -107,7 +109,7 @@ try
                 }
 
                 It 'Should return LogFlags' {
-                    $result.LogFlags | Should Be $MockLogOutput.logExtFileFlags
+                    $result.LogFlags | Should Be $MockLogFlagsAfterSplit
                 }
 
                 It 'Should return LogFlags as expected array of Strings' {

--- a/Tests/Unit/MSFT_xIISLogging.Tests.ps1
+++ b/Tests/Unit/MSFT_xIISLogging.Tests.ps1
@@ -67,7 +67,7 @@ try
                 customFields      = @{Collection = @($MockLogCustomFields)}
             }
 
-        $MockLogFlagsAfterSplit = [System.String[]]@('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
+        $MockLogFlagsAfterSplit = [System.String[]] @('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
 
         Describe "$script:DSCResourceName\Assert-Module" {
 

--- a/Tests/Unit/MSFT_xIISLogging.Tests.ps1
+++ b/Tests/Unit/MSFT_xIISLogging.Tests.ps1
@@ -58,7 +58,7 @@ try
         $MockLogOutput =
             @{
                 directory         = '%SystemDrive%\inetpub\logs\LogFiles'
-                logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
+                logExtFileFlags   = 'Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus'
                 logFormat         = 'W3C'
                 LogTargetW3C      = 'File,ETW'
                 period            = 'Daily'

--- a/Tests/Unit/MSFT_xIISLogging.Tests.ps1
+++ b/Tests/Unit/MSFT_xIISLogging.Tests.ps1
@@ -58,7 +58,7 @@ try
         $MockLogOutput =
             @{
                 directory         = '%SystemDrive%\inetpub\logs\LogFiles'
-                logExtFileFlags   = [System.String[]]@('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
+                logExtFileFlags   = 'Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus'
                 logFormat         = 'W3C'
                 LogTargetW3C      = 'File,ETW'
                 period            = 'Daily'

--- a/Tests/Unit/MSFT_xIISLogging.Tests.ps1
+++ b/Tests/Unit/MSFT_xIISLogging.Tests.ps1
@@ -110,6 +110,26 @@ try
                     $result.LogFlags | Should Be $MockLogOutput.logExtFileFlags
                 }
 
+                It 'Should return LogFlags as expected array of Strings' {
+                    $result.LogFlags -is [System.String[]] | Should -BeTrue
+                    $result.LogFlags | Should -HaveCount 15
+                    $result.LogFlags | Should -Contain 'Date'
+                    $result.LogFlags | Should -Contain 'Time'
+                    $result.LogFlags | Should -Contain 'ClientIP'
+                    $result.LogFlags | Should -Contain 'UserName'
+                    $result.LogFlags | Should -Contain 'ServerIP'
+                    $result.LogFlags | Should -Contain 'Method'
+                    $result.LogFlags | Should -Contain 'UriStem'
+                    $result.LogFlags | Should -Contain 'UriQuery'
+                    $result.LogFlags | Should -Contain 'HttpStatus'
+                    $result.LogFlags | Should -Contain 'Win32Status'
+                    $result.LogFlags | Should -Contain 'TimeTaken'
+                    $result.LogFlags | Should -Contain 'ServerPort'
+                    $result.LogFlags | Should -Contain 'UserAgent'
+                    $result.LogFlags | Should -Contain 'Referer'
+                    $result.LogFlags | Should -Contain 'HttpSubStatus'
+                }
+
                 It 'Should return LogPeriod' {
                     $result.LogPeriod | Should Be $MockLogOutput.period
                 }

--- a/Tests/Unit/MSFT_xIISLogging.Tests.ps1
+++ b/Tests/Unit/MSFT_xIISLogging.Tests.ps1
@@ -58,7 +58,7 @@ try
         $MockLogOutput =
             @{
                 directory         = '%SystemDrive%\inetpub\logs\LogFiles'
-                logExtFileFlags   = 'Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus'
+                logExtFileFlags   = [System.String[]]@('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
                 logFormat         = 'W3C'
                 LogTargetW3C      = 'File,ETW'
                 period            = 'Daily'

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -101,7 +101,7 @@ try
 
             $MockLogOutput = @{
                 directory         = '%SystemDrive%\inetpub\logs\LogFiles'
-                logExtFileFlags   = 'Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus'
+                logExtFileFlags   = 'Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus'
                 logFormat         = $MockParameters.LogFormat
                 period            = 'Daily'
                 logTargetW3C      = 'File,ETW'

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -101,7 +101,7 @@ try
 
             $MockLogOutput = @{
                 directory         = '%SystemDrive%\inetpub\logs\LogFiles'
-                logExtFileFlags   = 'Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus'
+                logExtFileFlags   = [System.String[]]@('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
                 logFormat         = $MockParameters.LogFormat
                 period            = 'Daily'
                 logTargetW3C      = 'File,ETW'

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -273,6 +273,26 @@ try
                     $Result.LogFlags | Should Be $MockWebsite.Logfile.logExtFileFlags
                 }
 
+                It 'should return LogFlags as expected array of Strings' {
+                    $Result.LogFlags -is [System.String[]] | Should -BeTrue
+                    $Result.LogFlags | Should -HaveCount 15
+                    $Result.LogFlags | Should -Contain 'Date'
+                    $Result.LogFlags | Should -Contain 'Time'
+                    $Result.LogFlags | Should -Contain 'ClientIP'
+                    $Result.LogFlags | Should -Contain 'UserName'
+                    $Result.LogFlags | Should -Contain 'ServerIP'
+                    $Result.LogFlags | Should -Contain 'Method'
+                    $Result.LogFlags | Should -Contain 'UriStem'
+                    $Result.LogFlags | Should -Contain 'UriQuery'
+                    $Result.LogFlags | Should -Contain 'HttpStatus'
+                    $Result.LogFlags | Should -Contain 'Win32Status'
+                    $Result.LogFlags | Should -Contain 'TimeTaken'
+                    $Result.LogFlags | Should -Contain 'ServerPort'
+                    $Result.LogFlags | Should -Contain 'UserAgent'
+                    $Result.LogFlags | Should -Contain 'Referer'
+                    $Result.LogFlags | Should -Contain 'HttpSubStatus'
+                }
+
                 It 'should return LogPeriod' {
                     $Result.LogPeriod | Should Be $MockWebsite.Logfile.period
                 }

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -124,7 +124,7 @@ try
                 Count                = 1
             }
 
-            $MockLogFlagsAfterSplit = [System.String[]]@('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
+            $MockLogFlagsAfterSplit = [System.String[]] @('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
 
             Mock -CommandName Assert-Module -MockWith {}
 

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -124,6 +124,8 @@ try
                 Count                = 1
             }
 
+            $MockLogFlagsAfterSplit = [System.String[]]@('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
+
             Mock -CommandName Assert-Module -MockWith {}
 
             Context 'Website does not exist' {
@@ -270,7 +272,7 @@ try
                 }
 
                 It 'should return LogFlags' {
-                    $Result.LogFlags | Should Be $MockWebsite.Logfile.logExtFileFlags
+                    $Result.LogFlags | Should Be $MockLogFlagsAfterSplit
                 }
 
                 It 'should return LogFlags as expected array of Strings' {

--- a/Tests/Unit/MSFT_xWebsite.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebsite.Tests.ps1
@@ -101,7 +101,7 @@ try
 
             $MockLogOutput = @{
                 directory         = '%SystemDrive%\inetpub\logs\LogFiles'
-                logExtFileFlags   = [System.String[]]@('Date','Time','ClientIP','UserName','ServerIP','Method','UriStem','UriQuery','HttpStatus','Win32Status','TimeTaken','ServerPort','UserAgent','Referer','HttpSubStatus')
+                logExtFileFlags   = 'Date,Time,ClientIP,UserName,ServerIP,Method,UriStem,UriQuery,HttpStatus,Win32Status,TimeTaken,ServerPort,UserAgent,Referer,HttpSubStatus'
                 logFormat         = $MockParameters.LogFormat
                 period            = 'Daily'
                 logTargetW3C      = 'File,ETW'


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
`Get-TargetResource` for `xWebsite` and `xIISLogging` return a hashtable that includes the `LogFlags` property. It is cast to an array but is not split which results in an array with a single String value inside of all LogFlags separated by commas. This fix correctly splits the string before casting to an Array.

#### This Pull Request (PR) fixes the following issues
- Fixes #405 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/440)
<!-- Reviewable:end -->
