### PR TITLE
xWebVirtualDirectory: Moving strings to localization file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Changes to xWebAdministration
+  - Moved MSFT_xWebVirtualDirectory localization strings to strings.psd1.
   - Resolved custom Script Analyzer rules that was added to the test framework.
   - Moved change log from README.md to a separate CHANGELOG.md ([issue #446](https://github.com/PowerShell/xWebAdministration/issues/446)).
   - Remove example 'Creating the default website using configuration data' from README.md ([issue #488](https://github.com/PowerShell/xWebAdministration/issues/488)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
+- Changes to xWebVirtualDirectory
+  - Moved MSFT_xWebVirtualDirectory localization strings to strings.psd1 ([issue #477](https://github.com/PowerShell/xWebAdministration/issues/477)).
 - Changes to xWebAdministration
-  - Moved MSFT_xWebVirtualDirectory localization strings to strings.psd1.
   - Resolved custom Script Analyzer rules that was added to the test framework.
   - Moved change log from README.md to a separate CHANGELOG.md ([issue #446](https://github.com/PowerShell/xWebAdministration/issues/446)).
   - Remove example 'Creating the default website using configuration data' from README.md ([issue #488](https://github.com/PowerShell/xWebAdministration/issues/488)).

--- a/DSCResources/MSFT_xWebVirtualDirectory/MSFT_xWebVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xWebVirtualDirectory/MSFT_xWebVirtualDirectory.psm1
@@ -187,7 +187,7 @@ function Test-TargetResource
         }
         else
         {
-            Write-Verbose -Message ($LocalizedData.VerboseTestTargetFalse -f $PhysicalPath, $Name)
+            Write-Verbose -Message ($script:localizedData.VerboseTestTargetFalse -f $PhysicalPath, $Name)
             return $false
         }
     }

--- a/DSCResources/MSFT_xWebVirtualDirectory/MSFT_xWebVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xWebVirtualDirectory/MSFT_xWebVirtualDirectory.psm1
@@ -4,20 +4,8 @@ $script:localizationModulePath = Join-Path -Path $script:modulesFolderPath -Chil
 
 Import-Module -Name (Join-Path -Path $script:localizationModulePath -ChildPath 'xWebAdministration.Common.psm1')
 
-# Localized messages
-data LocalizedData
-{
-    # culture="en-US"
-    ConvertFrom-StringData -StringData @'
-        VerboseGetTargetResource               = Get-TargetResource has been run.
-        VerboseSetTargetPhysicalPath           = Updating physical path for web virtual directory "{0}".
-        VerboseSetTargetCreateVirtualDirectory = Creating new Web Virtual Directory "{0}".
-        VerboseSetTargetRemoveVirtualDirectory = Removing existing Virtual Directory "{0}".
-        VerboseTestTargetFalse                 = Physical path "{0}" for web virtual directory "{1}" does not match desired state.
-        VerboseTestTargetTrue                  = Web virtual directory is in required state.
-        VerboseTestTargetAbsentTrue            = Web virtual directory "{0}" should be absent and is absent.
-'@
-}
+# Import Localization Strings
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xWebVirtualDirectory'
 
 function Get-TargetResource
 {

--- a/DSCResources/MSFT_xWebVirtualDirectory/MSFT_xWebVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xWebVirtualDirectory/MSFT_xWebVirtualDirectory.psm1
@@ -50,7 +50,7 @@ function Get-TargetResource
         $Ensure = 'Present'
     }
 
-    Write-Verbose -Message ($LocalizedData.VerboseGetTargetResource)
+    Write-Verbose -Message ($script:localizedData.VerboseGetTargetResource)
 
     $returnValue = @{
         Name           = $Name
@@ -104,7 +104,7 @@ function Set-TargetResource
                                                     -Application $WebApplication
         if ($virtualDirectory.count -eq 0)
         {
-            Write-Verbose -Message ($LocalizedData.VerboseSetTargetCreateVirtualDirectory -f $Name)
+            Write-Verbose -Message ($script:localizedData.VerboseSetTargetCreateVirtualDirectory -f $Name)
             New-WebVirtualDirectory -Site $Website `
                                     -Application $WebApplication `
                                     -Name $Name `
@@ -112,7 +112,7 @@ function Set-TargetResource
         }
         else
         {
-            Write-Verbose -Message ($LocalizedData.VerboseSetTargetPhysicalPath -f $Name)
+            Write-Verbose -Message ($script:localizedData.VerboseSetTargetPhysicalPath -f $Name)
 
             if ($WebApplication.Length -gt 0)
             {
@@ -131,7 +131,7 @@ function Set-TargetResource
 
     if ($Ensure -eq 'Absent')
     {
-        Write-Verbose -Message ($LocalizedData.VerboseSetTargetRemoveVirtualDirectory -f $Name)
+        Write-Verbose -Message ($script:localizedData.VerboseSetTargetRemoveVirtualDirectory -f $Name)
         Remove-WebVirtualDirectory -Site $Website `
                                    -Application $WebApplication `
                                    -Name $Name
@@ -182,7 +182,7 @@ function Test-TargetResource
     {
         if ($virtualDirectory.PhysicalPath -eq $PhysicalPath)
         {
-            Write-Verbose -Message ($LocalizedData.VerboseTestTargetTrue)
+            Write-Verbose -Message ($script:localizedData.VerboseTestTargetTrue)
             return $true
         }
         else
@@ -194,7 +194,7 @@ function Test-TargetResource
 
     if ($virtualDirectory.count -eq 0 -and $Ensure -eq 'Absent')
     {
-        Write-Verbose -Message ($LocalizedData.VerboseTestTargetAbsentTrue -f $Name)
+        Write-Verbose -Message ($script:localizedData.VerboseTestTargetAbsentTrue -f $Name)
         return $true
     }
 

--- a/DSCResources/MSFT_xWebVirtualDirectory/en-US/MSFT_xWebVirtualDirectory.strings.psd1
+++ b/DSCResources/MSFT_xWebVirtualDirectory/en-US/MSFT_xWebVirtualDirectory.strings.psd1
@@ -1,0 +1,10 @@
+# culture      ="en-US"
+ConvertFrom-StringData -StringData @'
+    VerboseGetTargetResource               = Get-TargetResource has been run.
+    VerboseSetTargetPhysicalPath           = Updating physical path for Web Virtual Directory '{0}'.
+    VerboseSetTargetCreateVirtualDirectory = Creating new Web Virtual Directory '{0}'.
+    VerboseSetTargetRemoveVirtualDirectory = Removing existing Virtual Directory '{0}'.
+    VerboseTestTargetFalse                 = Physical path '{0}' for Web Virtual Directory '{1}' is not in desired state.
+    VerboseTestTargetTrue                  = Web Virtual Directory is in desired state.
+    VerboseTestTargetAbsentTrue            = Web Virtual Directory '{0}' should be Absent and is Absent.
+'@


### PR DESCRIPTION
#### Pull Request (PR) description
MSFT_xWebVirtualDirectory: Moving strings to localization file

#### This Pull Request (PR) fixes the following issues
- Fixes #477 

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/512)
<!-- Reviewable:end -->
