### PR TITLE
xIisMimeTypeMapping: Moving strings to localization file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Changes to xWebAdministration
+  - Moved MSFT_xIisMimeTypeMapping localization strings to strings.psd1.
   - Resolved custom Script Analyzer rules that was added to the test framework.
   - Moved change log from README.md to a separate CHANGELOG.md ([issue #446](https://github.com/PowerShell/xWebAdministration/issues/446)).
   - Remove example 'Creating the default website using configuration data' from README.md ([issue #488](https://github.com/PowerShell/xWebAdministration/issues/488)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
+- Changes to xIisMimeTypeMapping
+  - Moved MSFT_xIisMimeTypeMapping localization strings to strings.psd1 ([issue #465](https://github.com/PowerShell/xWebAdministration/issues/465)).
 - Changes to xWebAdministration
-  - Moved MSFT_xIisMimeTypeMapping localization strings to strings.psd1.
   - Resolved custom Script Analyzer rules that was added to the test framework.
   - Moved change log from README.md to a separate CHANGELOG.md ([issue #446](https://github.com/PowerShell/xWebAdministration/issues/446)).
   - Remove example 'Creating the default website using configuration data' from README.md ([issue #488](https://github.com/PowerShell/xWebAdministration/issues/488)).

--- a/DSCResources/MSFT_xIisMimeTypeMapping/MSFT_xIisMimeTypeMapping.psm1
+++ b/DSCResources/MSFT_xIisMimeTypeMapping/MSFT_xIisMimeTypeMapping.psm1
@@ -4,20 +4,8 @@ $script:localizationModulePath = Join-Path -Path $script:modulesFolderPath -Chil
 
 Import-Module -Name (Join-Path -Path $script:localizationModulePath -ChildPath 'xWebAdministration.Common.psm1')
 
-# Localized messages
-data LocalizedData
-{
-    # culture="en-US"
-    ConvertFrom-StringData -StringData @'
-        NoWebAdministrationModule = Please ensure that WebAdministration module is installed.
-        AddingType                = Adding MIMEType '{0}' for extension '{1}'
-        RemovingType              = Removing MIMEType '{0}' for extension '{1}'
-        TypeExists                = MIMEType '{0}' for extension '{1}' already exist
-        TypeNotPresent            = MIMEType '{0}' for extension '{1}' is not present as requested
-        VerboseGetTargetPresent   = MIMEType is present
-        VerboseGetTargetAbsent    = MIMEType is absent
-'@
-}
+# Import Localization Strings
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xIisMimeTypeMapping'
 
 Set-Variable ConstDefaultConfigurationPath -Option Constant -Value 'MACHINE/WEBROOT/APPHOST' -Scope Script
 Set-Variable ConstSectionNode              -Option Constant -Value 'system.webServer/staticContent' -Scope Script

--- a/DSCResources/MSFT_xIisMimeTypeMapping/MSFT_xIisMimeTypeMapping.psm1
+++ b/DSCResources/MSFT_xIisMimeTypeMapping/MSFT_xIisMimeTypeMapping.psm1
@@ -63,7 +63,7 @@ function Get-TargetResource
 
     if ($null -eq $currentMimeTypeMapping)
     {
-        Write-Verbose -Message $LocalizedData.VerboseGetTargetAbsent
+        Write-Verbose -Message $script:localizedData.VerboseGetTargetAbsent
         return @{
             Ensure            = 'Absent'
             ConfigurationPath = $ConfigurationPath
@@ -73,7 +73,7 @@ function Get-TargetResource
     }
     else
     {
-        Write-Verbose -Message $LocalizedData.VerboseGetTargetPresent
+        Write-Verbose -Message $script:localizedData.VerboseGetTargetPresent
         return @{
             Ensure            = 'Present'
             ConfigurationPath = $ConfigurationPath
@@ -137,7 +137,7 @@ function Set-TargetResource
                                      -Filter $ConstSectionNode `
                                      -Name '.' `
                                      -Value @{fileExtension="$Extension";mimeType="$MimeType"}
-        Write-Verbose -Message ($LocalizedData.AddingType -f $MimeType,$Extension)
+        Write-Verbose -Message ($script:localizedData.AddingType -f $MimeType,$Extension)
     }
     else
     {
@@ -146,7 +146,7 @@ function Set-TargetResource
                                         -Filter $ConstSectionNode `
                                         -Name '.' `
                                         -AtElement @{fileExtension="$Extension"}
-        Write-Verbose -Message ($LocalizedData.RemovingType -f $MimeType,$Extension)
+        Write-Verbose -Message ($script:localizedData.RemovingType -f $MimeType,$Extension)
     }
 }
 
@@ -205,11 +205,11 @@ function Test-TargetResource
 
     if ($null -ne $currentMimeTypeMapping -and $Ensure -eq 'Present')
     {
-        Write-Verbose -Message ($LocalizedData.TypeExists -f $MimeType,$Extension)
+        Write-Verbose -Message ($script:localizedData.TypeExists -f $MimeType,$Extension)
     }
     elseif ($null -eq $currentMimeTypeMapping -and $Ensure -eq 'Absent')
     {
-        Write-Verbose -Message ($LocalizedData.TypeNotPresent -f $MimeType,$Extension)
+        Write-Verbose -Message ($script:localizedData.TypeNotPresent -f $MimeType,$Extension)
     }
     else
     {

--- a/DSCResources/MSFT_xIisMimeTypeMapping/en-US/MSFT_xIisMimeTypeMapping.strings.psd1
+++ b/DSCResources/MSFT_xIisMimeTypeMapping/en-US/MSFT_xIisMimeTypeMapping.strings.psd1
@@ -1,0 +1,10 @@
+# culture      ="en-US"
+ConvertFrom-StringData -StringData @'
+    NoWebAdministrationModule = Please ensure that WebAdministration module is installed.
+    AddingType                = Adding MIMEType '{0}' for extension '{1}'.
+    RemovingType              = Removing MIMEType '{0}' for extension '{1}'.
+    TypeExists                = MIMEType '{0}' for extension '{1}' is in desired state.
+    TypeNotPresent            = MIMEType '{0}' for extension '{1}' is not in desired State.
+    VerboseGetTargetPresent   = MIMEType is Present.
+    VerboseGetTargetAbsent    = MIMEType is Absent.
+'@


### PR DESCRIPTION
#### Pull Request (PR) description
    MSFT_xIisMimeTypeMapping: Moving strings to localization file

#### This Pull Request (PR) fixes the following issues
- Fixes #465 

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/513)
<!-- Reviewable:end -->
