### PR TITLE
xWebConfigPropertyCollection: Move localization strings to strings.psd1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Changes to xWebConfigPropertyCollection
+  - Move localization strings to strings.psd1 file ([Issue #474](https://github.com/PowerShell/xWebAdministration/issues/474))
 - Changes to xWebAdministration
   - Resolved custom Script Analyzer rules that was added to the test framework.
   - Moved change log from README.md to a separate CHANGELOG.md ([issue #446](https://github.com/PowerShell/xWebAdministration/issues/446)).

--- a/DSCResources/MSFT_xWebConfigPropertyCollection/MSFT_xWebConfigPropertyCollection.psm1
+++ b/DSCResources/MSFT_xWebConfigPropertyCollection/MSFT_xWebConfigPropertyCollection.psm1
@@ -76,7 +76,7 @@ function Get-TargetResource
     )
     # Retrieve the values of the existing property collection item if present.
     Write-Verbose `
-        -Message ($script:LocalizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
+        -Message ($script:localizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
 
     $existingItem = Get-ItemValues `
                         -WebsitePath $WebsitePath `
@@ -102,7 +102,7 @@ function Get-TargetResource
     {
         # Property collection item with specified key was not found.
         Write-Verbose `
-            -Message ($script:LocalizedData.VerboseTargetItemNotFound -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue )
+            -Message ($script:localizedData.VerboseTargetItemNotFound -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue )
 
         $result.Ensure = 'Absent'
         $result.ItemPropertyValue = $null
@@ -111,7 +111,7 @@ function Get-TargetResource
     {
         # Property collection item with specified key was found, but property was not present.
         Write-Verbose `
-            -Message ($script:LocalizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
+            -Message ($script:localizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
 
         $result.Ensure = 'Absent'
         $result.ItemPropertyValue = $null
@@ -120,7 +120,7 @@ function Get-TargetResource
     {
         # Property collection item with specified key was found.
         Write-Verbose `
-            -Message ($script:LocalizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
+            -Message ($script:localizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
 
         $result.Ensure = 'Present'
         $result.ItemPropertyValue = $existingItem[$ItemPropertyName].ToString()
@@ -212,7 +212,7 @@ function Set-TargetResource
     {
         # Retrieve the values of the existing property collection item if present.
         Write-Verbose `
-            -Message ($script:LocalizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
+            -Message ($script:localizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
 
         $existingItem = Get-ItemValues `
                             -WebsitePath $WebsitePath `
@@ -237,7 +237,7 @@ function Set-TargetResource
         {
             # Property collection item with specified key was not found.
             Write-Verbose `
-                -Message ($script:LocalizedData.VerboseSetTargetAddItem -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $ItemPropertyName )
+                -Message ($script:localizedData.VerboseSetTargetAddItem -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $ItemPropertyName )
 
             $filter = "$($Filter)/$($CollectionName)"
             # Use Add- in this case to add the element (including the key/value) and also the specified property name/value.
@@ -251,7 +251,7 @@ function Set-TargetResource
         {
             # Property collection item with specified key was found.
             Write-Verbose `
-                -Message ($script:LocalizedData.VerboseSetTargetEditItem -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $ItemPropertyName )
+                -Message ($script:localizedData.VerboseSetTargetEditItem -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $ItemPropertyName )
 
             $filter = "$($Filter)/$($CollectionName)/$($ItemName)[@$($ItemKeyName)='$($ItemKeyValue)']"
             # Use Set- in this case to update the specified property of the element with the specified key/value.
@@ -266,7 +266,7 @@ function Set-TargetResource
     {
         # Remove the specified property from the element with the specified key/value.
         Write-Verbose `
-            -Message ($script:LocalizedData.VerboseSetTargetRemoveItem -f $ItemPropertyName )
+            -Message ($script:localizedData.VerboseSetTargetRemoveItem -f $ItemPropertyName )
 
         $filter = "$($Filter)/$($CollectionName)"
         Remove-WebConfigurationProperty `
@@ -360,7 +360,7 @@ function Test-TargetResource
     )
     # Retrieve the values of the existing property collection item if present.
     Write-Verbose `
-        -Message ($script:LocalizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
+        -Message ($script:localizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
 
     $existingItem = Get-ItemValues `
                         -WebsitePath $WebsitePath `
@@ -376,7 +376,7 @@ function Test-TargetResource
         {
             # Property collection item with specified key was not found.
             Write-Verbose `
-                -Message ($script:LocalizedData.VerboseTargetItemNotFound -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue )
+                -Message ($script:localizedData.VerboseTargetItemNotFound -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue )
 
             return $false
         }
@@ -384,7 +384,7 @@ function Test-TargetResource
         {
             # Property collection item with specified key was found, but property was not present.
             Write-Verbose `
-                -Message ($script:LocalizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
+                -Message ($script:localizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
 
             return $false
         }
@@ -392,13 +392,13 @@ function Test-TargetResource
         {
             # Property collection item with specified key was found, but property did not have expected value.
             Write-Verbose `
-                -Message ($script:LocalizedData.VerboseTestTargetPropertyValueNotFound -f $ItemPropertyName )
+                -Message ($script:localizedData.VerboseTestTargetPropertyValueNotFound -f $ItemPropertyName )
 
             return $false
         }
         # Property collection item with specified key was found & had expected value.
         Write-Verbose `
-            -Message ($script:LocalizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
+            -Message ($script:localizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
 
         return $true
     }
@@ -408,13 +408,13 @@ function Test-TargetResource
         {
             # Property collection item with specified key was found & property was present.
             Write-Verbose `
-                -Message ($script:LocalizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
+                -Message ($script:localizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
 
             return $false
         }
         # Property collection item with specified key was either not found or property was not present.
         Write-Verbose `
-            -Message ($script:LocalizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
+            -Message ($script:localizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
 
         return $true
     }

--- a/DSCResources/MSFT_xWebConfigPropertyCollection/MSFT_xWebConfigPropertyCollection.psm1
+++ b/DSCResources/MSFT_xWebConfigPropertyCollection/MSFT_xWebConfigPropertyCollection.psm1
@@ -76,7 +76,7 @@ function Get-TargetResource
     )
     # Retrieve the values of the existing property collection item if present.
     Write-Verbose `
-        -Message ($LocalizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
+        -Message ($script:LocalizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
 
     $existingItem = Get-ItemValues `
                         -WebsitePath $WebsitePath `
@@ -102,7 +102,7 @@ function Get-TargetResource
     {
         # Property collection item with specified key was not found.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseTargetItemNotFound -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue )
+            -Message ($script:LocalizedData.VerboseTargetItemNotFound -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue )
 
         $result.Ensure = 'Absent'
         $result.ItemPropertyValue = $null
@@ -111,7 +111,7 @@ function Get-TargetResource
     {
         # Property collection item with specified key was found, but property was not present.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
+            -Message ($script:LocalizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
 
         $result.Ensure = 'Absent'
         $result.ItemPropertyValue = $null
@@ -120,7 +120,7 @@ function Get-TargetResource
     {
         # Property collection item with specified key was found.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
+            -Message ($script:LocalizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
 
         $result.Ensure = 'Present'
         $result.ItemPropertyValue = $existingItem[$ItemPropertyName].ToString()
@@ -212,7 +212,7 @@ function Set-TargetResource
     {
         # Retrieve the values of the existing property collection item if present.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
+            -Message ($script:LocalizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
 
         $existingItem = Get-ItemValues `
                             -WebsitePath $WebsitePath `
@@ -237,7 +237,7 @@ function Set-TargetResource
         {
             # Property collection item with specified key was not found.
             Write-Verbose `
-                -Message ($LocalizedData.VerboseSetTargetAddItem -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $ItemPropertyName )
+                -Message ($script:LocalizedData.VerboseSetTargetAddItem -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $ItemPropertyName )
 
             $filter = "$($Filter)/$($CollectionName)"
             # Use Add- in this case to add the element (including the key/value) and also the specified property name/value.
@@ -251,7 +251,7 @@ function Set-TargetResource
         {
             # Property collection item with specified key was found.
             Write-Verbose `
-                -Message ($LocalizedData.VerboseSetTargetEditItem -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $ItemPropertyName )
+                -Message ($script:LocalizedData.VerboseSetTargetEditItem -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $ItemPropertyName )
 
             $filter = "$($Filter)/$($CollectionName)/$($ItemName)[@$($ItemKeyName)='$($ItemKeyValue)']"
             # Use Set- in this case to update the specified property of the element with the specified key/value.
@@ -266,7 +266,7 @@ function Set-TargetResource
     {
         # Remove the specified property from the element with the specified key/value.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseSetTargetRemoveItem -f $ItemPropertyName )
+            -Message ($script:LocalizedData.VerboseSetTargetRemoveItem -f $ItemPropertyName )
 
         $filter = "$($Filter)/$($CollectionName)"
         Remove-WebConfigurationProperty `
@@ -360,7 +360,7 @@ function Test-TargetResource
     )
     # Retrieve the values of the existing property collection item if present.
     Write-Verbose `
-        -Message ($LocalizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
+        -Message ($script:LocalizedData.VerboseTargetCheckingTarget -f $ItemPropertyName, $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue, $Filter, $WebsitePath )
 
     $existingItem = Get-ItemValues `
                         -WebsitePath $WebsitePath `
@@ -376,7 +376,7 @@ function Test-TargetResource
         {
             # Property collection item with specified key was not found.
             Write-Verbose `
-                -Message ($LocalizedData.VerboseTargetItemNotFound -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue )
+                -Message ($script:LocalizedData.VerboseTargetItemNotFound -f $CollectionName, $ItemName, $ItemKeyName, $ItemKeyValue )
 
             return $false
         }
@@ -384,7 +384,7 @@ function Test-TargetResource
         {
             # Property collection item with specified key was found, but property was not present.
             Write-Verbose `
-                -Message ($LocalizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
+                -Message ($script:LocalizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
 
             return $false
         }
@@ -392,13 +392,13 @@ function Test-TargetResource
         {
             # Property collection item with specified key was found, but property did not have expected value.
             Write-Verbose `
-                -Message ($LocalizedData.VerboseTestTargetPropertyValueNotFound -f $ItemPropertyName )
+                -Message ($script:LocalizedData.VerboseTestTargetPropertyValueNotFound -f $ItemPropertyName )
 
             return $false
         }
         # Property collection item with specified key was found & had expected value.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
+            -Message ($script:LocalizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
 
         return $true
     }
@@ -408,13 +408,13 @@ function Test-TargetResource
         {
             # Property collection item with specified key was found & property was present.
             Write-Verbose `
-                -Message ($LocalizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
+                -Message ($script:LocalizedData.VerboseTargetPropertyFound -f $ItemPropertyName )
 
             return $false
         }
         # Property collection item with specified key was either not found or property was not present.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
+            -Message ($script:LocalizedData.VerboseTargetPropertyNotFound -f $ItemPropertyName )
 
         return $true
     }

--- a/DSCResources/MSFT_xWebConfigPropertyCollection/MSFT_xWebConfigPropertyCollection.psm1
+++ b/DSCResources/MSFT_xWebConfigPropertyCollection/MSFT_xWebConfigPropertyCollection.psm1
@@ -4,21 +4,9 @@ $script:localizationModulePath = Join-Path -Path $script:modulesFolderPath -Chil
 
 Import-Module -Name (Join-Path -Path $script:localizationModulePath -ChildPath 'xWebAdministration.Common.psm1')
 
-# Localized messages
-data LocalizedData
-{
-    # culture="en-US"
-    ConvertFrom-StringData -StringData @'
-    VerboseTargetCheckingTarget            = Checking for the existence of property "{0}" in collection item "{1}/{2}" with key "{3}={4}" using filter "{5}" located at "{6}".
-    VerboseTargetItemNotFound              = Collection item "{0}/{1}" with key "{2}={3}" has not been found.
-    VerboseTargetPropertyNotFound          = Property "{0}" has not been found.
-    VerboseTargetPropertyFound             = Property "{0}" has been found.
-    VerboseSetTargetAddItem                = Collection item "{0}/{1}" with key "{2}={3}" does not exist, adding with property "{4}".
-    VerboseSetTargetEditItem               = Collection item "{0}/{1}" with key "{2}={3}" exists, editing property "{4}".
-    VerboseSetTargetRemoveItem             = Property "{0}" exists, removing property.
-    VerboseTestTargetPropertyValueNotFound = Property "{0}" has not been found with expected value.
-'@
-}
+# Import Localization Strings
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xWebConfigPropertyCollection'
+
 
 <#
 .SYNOPSIS

--- a/DSCResources/MSFT_xWebConfigPropertyCollection/en-US/MSFT_xWebConfigPropertyCollection.strings.psd1
+++ b/DSCResources/MSFT_xWebConfigPropertyCollection/en-US/MSFT_xWebConfigPropertyCollection.strings.psd1
@@ -1,0 +1,11 @@
+# culture="en-US"
+ConvertFrom-StringData -StringData @'
+    VerboseTargetCheckingTarget            = Checking for the existence of property "{0}" in collection item "{1}/{2}" with key "{3}={4}" using filter "{5}" located at "{6}".
+    VerboseTargetItemNotFound              = Collection item "{0}/{1}" with key "{2}={3}" has not been found.
+    VerboseTargetPropertyNotFound          = Property "{0}" has not been found.
+    VerboseTargetPropertyFound             = Property "{0}" has been found.
+    VerboseSetTargetAddItem                = Collection item "{0}/{1}" with key "{2}={3}" does not exist, adding with property "{4}".
+    VerboseSetTargetEditItem               = Collection item "{0}/{1}" with key "{2}={3}" exists, editing property "{4}".
+    VerboseSetTargetRemoveItem             = Property "{0}" exists, removing property.
+    VerboseTestTargetPropertyValueNotFound = Property "{0}" has not been found with expected value.
+'@


### PR DESCRIPTION
#### Pull Request (PR) description
MSFT_xWebConfigPropertyCollection: Move localization strings to strings.psd1


#### This Pull Request (PR) fixes the following issues
- Fixes #474

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/516)
<!-- Reviewable:end -->
