### PR TITLE
xWebConfigProperty: Move localization strings to strings.psd1 file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Changes to xWebConfigProperty
+  - Move localization strings to strings.psd1 file ([Issue #473](https://github.com/PowerShell/xWebAdministration/issues/473))
 - Changes to xWebAdministration
   - Resolved custom Script Analyzer rules that was added to the test framework.
   - Moved change log from README.md to a separate CHANGELOG.md ([issue #446](https://github.com/PowerShell/xWebAdministration/issues/446)).

--- a/DSCResources/MSFT_xWebConfigProperty/MSFT_xWebConfigProperty.psm1
+++ b/DSCResources/MSFT_xWebConfigProperty/MSFT_xWebConfigProperty.psm1
@@ -4,18 +4,8 @@ $script:localizationModulePath = Join-Path -Path $script:modulesFolderPath -Chil
 
 Import-Module -Name (Join-Path -Path $script:localizationModulePath -ChildPath 'xWebAdministration.Common.psm1')
 
-# Localized messages
-data LocalizedData
-{
-    # culture="en-US"
-    ConvertFrom-StringData -StringData @'
-    VerboseTargetCheckingTarget       = Checking for the existence of property "{0}" using filter "{1}" located at "{2}".
-    VerboseTargetPropertyNotFound     = Property "{0}" has not been found.
-    VerboseTargetPropertyFound        = Property "{0}" has been found.
-    VerboseSetTargetEditItem          = Ensuring property "{0}" is set.
-    VerboseSetTargetRemoveItem        = Property "{0}" exists, removing property.
-'@
-}
+# Import Localization Strings
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xWebConfigProperty'
 
 <#
 .SYNOPSIS

--- a/DSCResources/MSFT_xWebConfigProperty/MSFT_xWebConfigProperty.psm1
+++ b/DSCResources/MSFT_xWebConfigProperty/MSFT_xWebConfigProperty.psm1
@@ -43,7 +43,7 @@ function Get-TargetResource
     )
     # Retrieve the value of the existing property if present.
     Write-Verbose `
-        -Message ($LocalizedData.VerboseTargetCheckingTarget -f $PropertyName, $Filter, $WebsitePath )
+        -Message ($script:localizedData.VerboseTargetCheckingTarget -f $PropertyName, $Filter, $WebsitePath )
 
     $existingValue = Get-ItemValue `
                         -WebsitePath $WebsitePath `
@@ -62,7 +62,7 @@ function Get-TargetResource
     {
         # Property was not found.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseTargetPropertyNotFound -f $PropertyName )
+            -Message ($script:localizedData.VerboseTargetPropertyNotFound -f $PropertyName )
 
         $result.Ensure = 'Absent'
     }
@@ -70,7 +70,7 @@ function Get-TargetResource
     {
         # Property was found.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseTargetPropertyFound -f $PropertyName )
+            -Message ($script:localizedData.VerboseTargetPropertyFound -f $PropertyName )
     }
 
     return $result
@@ -128,7 +128,7 @@ function Set-TargetResource
     {
         # Property needs to be updated.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseSetTargetEditItem -f $PropertyName )
+            -Message ($script:localizedData.VerboseSetTargetEditItem -f $PropertyName )
 
         $propertyType = Get-ItemPropertyType -WebsitePath $WebsitePath -Filter $Filter -PropertyName $PropertyName
 
@@ -152,7 +152,7 @@ function Set-TargetResource
     {
         # Property needs to be removed.
         Write-Verbose `
-            -Message ($LocalizedData.VerboseSetTargetRemoveItem -f $PropertyName )
+            -Message ($script:localizedData.VerboseSetTargetRemoveItem -f $PropertyName )
 
         Clear-WebConfiguration `
                 -Filter "$($Filter)/@$($PropertyName)" `
@@ -212,7 +212,7 @@ function Test-TargetResource
     )
     # Retrieve the value of the existing property if present.
     Write-Verbose `
-        -Message ($LocalizedData.VerboseTargetCheckingTarget -f $PropertyName, $Filter, $WebsitePath )
+        -Message ($script:localizedData.VerboseTargetCheckingTarget -f $PropertyName, $Filter, $WebsitePath )
 
     $targetResource = Get-TargetResource `
                         -WebsitePath $WebsitePath `
@@ -225,7 +225,7 @@ function Test-TargetResource
         {
             # Property was not found or didn't have expected value.
             Write-Verbose `
-                -Message ($LocalizedData.VerboseTargetPropertyNotFound -f $PropertyName )
+                -Message ($script:localizedData.VerboseTargetPropertyNotFound -f $PropertyName )
 
             return $false
         }
@@ -236,14 +236,14 @@ function Test-TargetResource
         {
             # Property was found.
                 Write-Verbose `
-                -Message ($LocalizedData.VerboseTargetPropertyWasFound -f $PropertyName )
+                -Message ($script:localizedData.VerboseTargetPropertyWasFound -f $PropertyName )
 
             return $false
         }
     }
 
     Write-Verbose `
-            -Message ($LocalizedData.VerboseTargetPropertyWasFound -f $PropertyName)
+            -Message ($script:localizedData.VerboseTargetPropertyWasFound -f $PropertyName)
 
     return $true
 }

--- a/DSCResources/MSFT_xWebConfigProperty/en-US/MSFT_xWebConfigProperty.strings.psd1
+++ b/DSCResources/MSFT_xWebConfigProperty/en-US/MSFT_xWebConfigProperty.strings.psd1
@@ -1,0 +1,8 @@
+# culture="en-US"
+ConvertFrom-StringData -StringData @'
+    VerboseTargetCheckingTarget       = Checking for the existence of property "{0}" using filter "{1}" located at "{2}".
+    VerboseTargetPropertyNotFound     = Property "{0}" has not been found.
+    VerboseTargetPropertyFound        = Property "{0}" has been found.
+    VerboseSetTargetEditItem          = Ensuring property "{0}" is set.
+    VerboseSetTargetRemoveItem        = Property "{0}" exists, removing property.
+'@


### PR DESCRIPTION
#### Pull Request (PR) description
xWebConfigProperty: Move localization strings to strings.psd1 file

#### This Pull Request (PR) fixes the following issues
- Fixes #473 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/517)
<!-- Reviewable:end -->
