### PR TITLE
xWebAppPoolDefaults: Move localization strings to strings.psd1 file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Changes to xWebAppPoolDefaults
+  - Move localization strings to strings.psd1 file ([Issue #470](https://github.com/PowerShell/xWebAdministration/issues/470))
 - Changes to xWebAdministration
   - Resolved custom Script Analyzer rules that was added to the test framework.
   - Moved change log from README.md to a separate CHANGELOG.md ([issue #446](https://github.com/PowerShell/xWebAdministration/issues/446)).

--- a/DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.psm1
+++ b/DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.psm1
@@ -4,17 +4,8 @@ $script:localizationModulePath = Join-Path -Path $script:modulesFolderPath -Chil
 
 Import-Module -Name (Join-Path -Path $script:localizationModulePath -ChildPath 'xWebAdministration.Common.psm1')
 
-# Localized messages
-data LocalizedData
-{
-    # culture="en-US"
-    ConvertFrom-StringData -StringData @'
-        NoWebAdministrationModule = Please ensure that WebAdministration module is installed.
-        SettingValue              = Changing default value '{0}' to '{1}'
-        ValueOk                   = Default value '{0}' is already '{1}'
-        VerboseGetTargetResource  = Get-TargetResource has been run.
-'@
-}
+# Import Localization Strings
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xWebAppPoolDefaults'
 
 function Get-TargetResource
 {

--- a/DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.psm1
+++ b/DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.psm1
@@ -26,7 +26,7 @@ function Get-TargetResource
 
     Assert-Module
 
-    Write-Verbose -Message $LocalizedData.VerboseGetTargetResource
+    Write-Verbose -Message $script:localizedData.VerboseGetTargetResource
 
     return @{
         ManagedRuntimeVersion = (Get-Value -Path '' -Name 'managedRuntimeVersion')
@@ -151,7 +151,7 @@ function Confirm-Value
     else
     {
         $relPath = $Path + '/' + $Name
-        Write-Verbose($LocalizedData.ValueOk -f $relPath,$NewValue);
+        Write-Verbose($script:localizedData.ValueOk -f $relPath,$NewValue);
         return $true
     }
 }
@@ -196,7 +196,7 @@ function Set-Value
             -Value "$NewValue"
 
         $relPath = $Path + '/' + $Name
-        Write-Verbose($LocalizedData.SettingValue -f $relPath,$NewValue);
+        Write-Verbose($script:localizedData.SettingValue -f $relPath,$NewValue);
     }
 }
 

--- a/DSCResources/MSFT_xWebAppPoolDefaults/en-US/MSFT_xWebAppPoolDefaults.strings.psd1
+++ b/DSCResources/MSFT_xWebAppPoolDefaults/en-US/MSFT_xWebAppPoolDefaults.strings.psd1
@@ -1,0 +1,7 @@
+# culture="en-US"
+ConvertFrom-StringData -StringData @'
+        NoWebAdministrationModule = Please ensure that WebAdministration module is installed.
+        SettingValue              = Changing default value '{0}' to '{1}'
+        ValueOk                   = Default value '{0}' is already '{1}'
+        VerboseGetTargetResource  = Get-TargetResource has been run.
+'@


### PR DESCRIPTION
Move localization strings to strings.psd1 file


#### This Pull Request (PR) fixes the following issues
Fixe #470 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/519)
<!-- Reviewable:end -->
