### PR TITLE
xIisModule: Move localization strings to strings.psd1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
+- Changes to xIisModule entry
+  - Moved xIisModule localization strings to strings.psd1 ([issue #466](https://github.com/PowerShell/xWebAdministration/issues/466)).
 - Changes to xWebAdministration
-  - Moved xIisModule localization strings to strings.psd1.
   - Resolved custom Script Analyzer rules that was added to the test framework.
   - Moved change log from README.md to a separate CHANGELOG.md ([issue #446](https://github.com/PowerShell/xWebAdministration/issues/446)).
   - Remove example 'Creating the default website using configuration data' from README.md ([issue #488](https://github.com/PowerShell/xWebAdministration/issues/488)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Changes to xWebAdministration
+  - Moved xIisModule localization strings to strings.psd1.
   - Resolved custom Script Analyzer rules that was added to the test framework.
   - Moved change log from README.md to a separate CHANGELOG.md ([issue #446](https://github.com/PowerShell/xWebAdministration/issues/446)).
   - Remove example 'Creating the default website using configuration data' from README.md ([issue #488](https://github.com/PowerShell/xWebAdministration/issues/488)).

--- a/DSCResources/MSFT_xIisModule/MSFT_xIisModule.psm1
+++ b/DSCResources/MSFT_xIisModule/MSFT_xIisModule.psm1
@@ -4,27 +4,9 @@ $script:localizationModulePath = Join-Path -Path $script:modulesFolderPath -Chil
 
 Import-Module -Name (Join-Path -Path $script:localizationModulePath -ChildPath 'xWebAdministration.Common.psm1')
 
-# Localized messages
-data LocalizedData
-{
-    # culture="en-US"
-    ConvertFrom-StringData -StringData @'
-        VerboseGetTargetResource                               = Get-TargetResource has been run.
-        VerboseSetTargetRemoveHandler                          = Removing handler
-        VerboseSetTargetAddHandler                             = Adding handler.
-        VerboseSetTargetAddfastCgi                             = Adding fastCgi.
-        VerboseTestTargetResource                              = Get-TargetResource has been run.
-        VerboseGetIisHandler                                   = Getting Handler for {0} in Site {1}
-        VerboseTestTargetResourceImplVerb                      = Matched Verb {0}
-        VerboseTestTargetResourceImplExtraVerb                 = Extra Verb {0}
-        VerboseTestTargetResourceImplRequestPath               = RequestPath is {0}
-        VerboseTestTargetResourceImplPath                      = Path is {0}
-        VerboseTestTargetResourceImplresourceStatusRequestPath = StatusRequestPath is {0}
-        VerboseTestTargetResourceImplresourceStatusPath        = StatusPath is {0}
-        VerboseTestTargetResourceImplModulePresent             = Module present is {0}
-        VerboseTestTargetResourceImplModuleConfigured          = ModuleConfigured is {0}
-'@
-}
+# Import Localization Strings
+$script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xIisModule'
+
 function Get-TargetResource
 {
     <#

--- a/DSCResources/MSFT_xIisModule/MSFT_xIisModule.psm1
+++ b/DSCResources/MSFT_xIisModule/MSFT_xIisModule.psm1
@@ -72,7 +72,7 @@ function Get-TargetResource
             }
         }
 
-        Write-Verbose -Message $LocalizedData.VerboseGetTargetResource
+        Write-Verbose -Message $script:localizedData.VerboseGetTargetResource
 
         $returnValue = @{
             Path          = $handler.ScriptProcessor
@@ -135,13 +135,13 @@ function Set-TargetResource
     {
         if ($resourceTests.ModulePresent -and -not $resourceTests.ModuleConfigured)
         {
-            Write-Verbose -Message $LocalizedData.VerboseSetTargetRemoveHandler
+            Write-Verbose -Message $script:localizedData.VerboseSetTargetRemoveHandler
             Remove-IisHandler
         }
 
         if (-not $resourceTests.ModulePresent -or -not $resourceTests.ModuleConfigured)
         {
-            Write-Verbose -Message $LocalizedData.VerboseSetTargetAddHandler
+            Write-Verbose -Message $script:localizedData.VerboseSetTargetAddHandler
             Add-webconfiguration /system.webServer/handlers iis:\ -Value @{
                 Name = $Name
                 Path = $RequestPath
@@ -153,7 +153,7 @@ function Set-TargetResource
 
         if (-not $resourceTests.EndPointSetup)
         {
-            Write-Verbose -Message $LocalizedData.VerboseSetTargetAddfastCgi
+            Write-Verbose -Message $script:localizedData.VerboseSetTargetAddfastCgi
             Add-WebConfiguration /system.webServer/fastCgi iis:\ -Value @{
                 FullPath = $Path
             }
@@ -161,7 +161,7 @@ function Set-TargetResource
     }
     else
     {
-        Write-Verbose -Message $LocalizedData.VerboseSetTargetRemoveHandler
+        Write-Verbose -Message $script:localizedData.VerboseSetTargetRemoveHandler
         Remove-IisHandler
     }
 }
@@ -205,7 +205,7 @@ function Test-TargetResource
     $getParameters = Get-PSBoundParameters -FunctionParameters $PSBoundParameters
     $resourceStatus = Get-TargetResource @GetParameters
 
-    Write-Verbose -Message $LocalizedData.VerboseTestTargetResource
+    Write-Verbose -Message $script:localizedData.VerboseTestTargetResource
 
     return (Test-TargetResourceImpl @PSBoundParameters -ResourceStatus $resourceStatus).Result
 }
@@ -271,7 +271,7 @@ function Get-IisHandler
         [String] $SiteName
     )
 
-    Write-Verbose -Message ($LocalizedData.VerboseGetIisHandler -f $Name,$SiteName)
+    Write-Verbose -Message ($script:localizedData.VerboseGetIisHandler -f $Name,$SiteName)
     return Get-Webconfiguration -Filter 'System.WebServer/handlers/*' `
                                 -PSPath (Get-IisSitePath `
                                 -SiteName $SiteName) | `
@@ -346,13 +346,13 @@ function Test-TargetResourceImpl
     {
         if ($Verb -icontains $thisVerb)
         {
-            Write-Verbose -Message ($LocalizedData.VerboseTestTargetResourceImplVerb `
+            Write-Verbose -Message ($script:localizedData.VerboseTestTargetResourceImplVerb `
                             -f $Verb)
             $matchedVerbs += $thisVerb
         }
         else
         {
-            Write-Verbose -Message ($LocalizedData.VerboseTestTargetResourceImplExtraVerb `
+            Write-Verbose -Message ($script:localizedData.VerboseTestTargetResourceImplExtraVerb `
                             -f $Verb)
             $mismatchVerbs += $thisVerb
         }
@@ -364,13 +364,13 @@ function Test-TargetResourceImpl
         $modulePresent = $true
     }
 
-    Write-Verbose -Message ($LocalizedData.VerboseTestTargetResourceImplRequestPath `
+    Write-Verbose -Message ($script:localizedData.VerboseTestTargetResourceImplRequestPath `
                             -f $RequestPath)
-    Write-Verbose -Message ($LocalizedData.VerboseTestTargetResourceImplPath `
+    Write-Verbose -Message ($script:localizedData.VerboseTestTargetResourceImplPath `
                             -f $Path)
-    Write-Verbose -Message ($LocalizedData.VerboseTestTargetResourceImplresourceStatusRequestPath `
+    Write-Verbose -Message ($script:localizedData.VerboseTestTargetResourceImplresourceStatusRequestPath `
                             -f $($resourceStatus.RequestPath))
-    Write-Verbose -Message ($LocalizedData.VerboseTestTargetResourceImplresourceStatusPath `
+    Write-Verbose -Message ($script:localizedData.VerboseTestTargetResourceImplresourceStatusPath `
                             -f $($resourceStatus.Path))
 
     $moduleConfigured = $false
@@ -383,9 +383,9 @@ function Test-TargetResourceImpl
         $moduleConfigured = $true
     }
 
-    Write-Verbose -Message ($LocalizedData.VerboseTestTargetResourceImplModulePresent `
+    Write-Verbose -Message ($script:localizedData.VerboseTestTargetResourceImplModulePresent `
                             -f $ModulePresent)
-    Write-Verbose -Message ($LocalizedData.VerboseTestTargetResourceImplModuleConfigured `
+    Write-Verbose -Message ($script:localizedData.VerboseTestTargetResourceImplModuleConfigured `
                             -f $ModuleConfigured)
     if ($moduleConfigured -and ($ModuleType -ne 'FastCgiModule' -or $resourceStatus.EndPointSetup))
     {

--- a/DSCResources/MSFT_xIisModule/en-US/MSFT_xIisModule.strings.psd1
+++ b/DSCResources/MSFT_xIisModule/en-US/MSFT_xIisModule.strings.psd1
@@ -1,0 +1,16 @@
+ConvertFrom-StringData @'
+    VerboseGetTargetResource                               = Get-TargetResource has been run.
+    VerboseSetTargetRemoveHandler                          = Removing handler.
+    VerboseSetTargetAddHandler                             = Adding handler.
+    VerboseSetTargetAddfastCgi                             = Adding fastCgi.
+    VerboseTestTargetResource                              = Get-TargetResource has been run.
+    VerboseGetIisHandler                                   = Getting Handler for '{0}' in Site '{1}'.
+    VerboseTestTargetResourceImplVerb                      = Matched Verb '{0}'.
+    VerboseTestTargetResourceImplExtraVerb                 = Extra Verb '{0}'.
+    VerboseTestTargetResourceImplRequestPath               = RequestPath is '{0}'.
+    VerboseTestTargetResourceImplPath                      = Path is '{0}'.
+    VerboseTestTargetResourceImplresourceStatusRequestPath = StatusRequestPath is '{0}'.
+    VerboseTestTargetResourceImplresourceStatusPath        = StatusPath is '{0}'.
+    VerboseTestTargetResourceImplModulePresent             = Module present is '{0}'.
+    VerboseTestTargetResourceImplModuleConfigured          = ModuleConfigured is '{0}'.
+'@


### PR DESCRIPTION
#### Pull Request (PR) description
MSFT_xIisModule: Move localization strings to strings.psd1

#### This Pull Request (PR) fixes the following issues
- Fixes #466 

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/521)
<!-- Reviewable:end -->
