### PR TITLE
BREAKING CHANGE: xWebAppPoolDefaults: Align to best practices for single instance resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
   - Updated schema.mof to include a description for the Ensure property ([issue #455](https://github.com/PowerShell/xWebAdministration/issues/455)).
 - Changes to xWebAppPoolDefaults
   - Move localization strings to strings.psd1 file ([issue #470](https://github.com/PowerShell/xWebAdministration/issues/470)).
+  - BREAKING CHANGE: Changed `ApplyTo` key parameter to `IsSingleInstance` to
+  bring the resource into compliance with published best practices. ([issue #462](https://github.com/PowerShell/xWebAdministration/issues/462))
 - Changes to xWebApplication
   - Move localization strings to strings.psd1 file ([Issue #468](https://github.com/PowerShell/xWebAdministration/issues/468))
 - Changes to xIisModule entry

--- a/DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.psm1
+++ b/DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.psm1
@@ -19,9 +19,9 @@ function Get-TargetResource
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Machine')]
+        [ValidateSet('Yes')]
         [System.String]
-        $ApplyTo
+        $IsSingleInstance
     )
 
     Assert-Module
@@ -46,9 +46,9 @@ function Set-TargetResource
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Machine')]
+        [ValidateSet('Yes')]
         [System.String]
-        $ApplyTo,
+        $IsSingleInstance,
 
         [Parameter()]
         [ValidateSet('','v2.0','v4.0')]
@@ -81,9 +81,9 @@ function Test-TargetResource
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Machine')]
+        [ValidateSet('Yes')]
         [System.String]
-        $ApplyTo,
+        $IsSingleInstance,
 
         [Parameter()]
         [ValidateSet('','v2.0','v4.0')]

--- a/DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.schema.mof
+++ b/DSCResources/MSFT_xWebAppPoolDefaults/MSFT_xWebAppPoolDefaults.schema.mof
@@ -2,7 +2,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xWebAppPoolDefaults")]
 class MSFT_xWebAppPoolDefaults : OMI_BaseResource
 {
-    [Key, Description("Dummy value because we need a key, always 'Machine'"), ValueMap{"Machine"}, Values{"Machine"}] string ApplyTo;
+    [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
     [write, Description("applicationPools/applicationPoolDefaults/managedRuntimeVersion"), ValueMap{"","v2.0","v4.0"}, Values{"","v2.0","v4.0"}] string ManagedRuntimeVersion;
     [write, Description("applicationPools/applicationPoolDefaults/processModel/identityType"), ValueMap{"ApplicationPoolIdentity","LocalService","LocalSystem","NetworkService"}, Values{"ApplicationPoolIdentity","LocalService","LocalSystem","NetworkService"}] string IdentityType;
 };

--- a/Examples/Resources/xIisServerDefaults/Sample_xIisServerDefaults.ps1
+++ b/Examples/Resources/xIisServerDefaults/Sample_xIisServerDefaults.ps1
@@ -21,7 +21,7 @@ configuration Sample_xIISServerDefaults
 
         xWebAppPoolDefaults PoolDefaults
         {
-            ApplyTo               = 'Machine'
+            IsSingleInstance      = 'Yes'
             ManagedRuntimeVersion = 'v4.0'
             IdentityType          = 'ApplicationPoolIdentity'
         }

--- a/Examples/Resources/xWebAppPoolDefaults/Sample_xWebAppPoolDefaults.ps1
+++ b/Examples/Resources/xWebAppPoolDefaults/Sample_xWebAppPoolDefaults.ps1
@@ -21,7 +21,7 @@ Configuration Sample_xWebAppPoolDefaults
         # Configures the application pool defaults.
         xWebAppPoolDefaults PoolDefaults
         {
-            ApplyTo               = 'Machine'
+            IsSingleInstance      = 'Yes'
             ManagedRuntimeVersion = 'v4.0'
             IdentityType          = 'ApplicationPoolIdentity'
         }

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 
 ### xWebAppPoolDefaults
 
-* **ApplyTo**: Required Key value, always **Machine**
+* **IsSingleInstance**: Specifies the resource is a single instance, the value must be **Yes**
 * **ManagedRuntimeVersion**: CLR Version {v2.0|v4.0|} empty string for unmanaged.
 * **ApplicationPoolIdentity**: {ApplicationPoolIdentity | LocalService | LocalSystem | NetworkService}
 
@@ -939,7 +939,7 @@ configuration Sample_IISServerDefaults
 
          xWebAppPoolDefaults PoolDefaults
          {
-            ApplyTo = 'Machine'
+            IsSingleInstance = 'Yes'
             ManagedRuntimeVersion = 'v4.0'
             IdentityType = 'ApplicationPoolIdentity'
          }

--- a/Tests/Integration/MSFT_xWebAppPoolDefaults.config.ps1
+++ b/Tests/Integration/MSFT_xWebAppPoolDefaults.config.ps1
@@ -10,7 +10,7 @@ configuration MSFT_xWebAppPoolDefaults_Config
 
     xWebAppPoolDefaults PoolDefaults
     {
-        ApplyTo = 'Machine'
+        IsSingleInstance = 'Yes'
         ManagedRuntimeVersion = $originalValue
     }
 }
@@ -21,7 +21,7 @@ configuration MSFT_xWebAppPoolDefaults_ManagedRuntimeVersion
 
     xWebAppPoolDefaults PoolDefaults
     {
-        ApplyTo = 'Machine'
+        IsSingleInstance = 'Yes'
         ManagedRuntimeVersion = $env:PesterManagedRuntimeVersion
     }
 }
@@ -32,7 +32,7 @@ configuration MSFT_xWebAppPoolDefaults_AppPoolIdentityType
 
     xWebAppPoolDefaults PoolDefaults
     {
-        ApplyTo = 'Machine'
+        IsSingleInstance = 'Yes'
         IdentityType = $env:PesterApplicationPoolIdentity
     }
 }

--- a/Tests/Unit/MSFT_xWebAppPoolDefaults.Tests.ps1
+++ b/Tests/Unit/MSFT_xWebAppPoolDefaults.Tests.ps1
@@ -58,7 +58,7 @@ try
                     }
                 }
 
-                $result = Get-TargetResource -ApplyTo 'Machine'
+                $result = Get-TargetResource -IsSingleInstance 'Yes'
 
                 It 'Should return managedRuntimeVersion' {
                     $result.managedRuntimeVersion | `
@@ -93,7 +93,7 @@ try
             }
 
             Context 'Application pool defaults correct' {
-                $result = Test-TargetResource -ApplyTo 'Machine' `
+                $result = Test-TargetResource -IsSingleInstance 'Yes' `
                             -ManagedRuntimeVersion 'v4.0' `
                             -IdentityType 'NetworkService'
 
@@ -103,7 +103,7 @@ try
             }
 
             Context 'Application pool different managedRuntimeVersion' {
-                $result = Test-TargetResource -ApplyTo 'Machine' `
+                $result = Test-TargetResource -IsSingleInstance 'Yes' `
                             -ManagedRuntimeVersion 'v2.0' `
                             -IdentityType 'NetworkService'
 
@@ -113,7 +113,7 @@ try
             }
 
             Context 'Application pool different processModel/@identityType' {
-                $result = Test-TargetResource -ApplyTo 'Machine' `
+                $result = Test-TargetResource -IsSingleInstance 'Yes' `
                             -ManagedRuntimeVersion 'v4.0' `
                             -IdentityType 'LocalSystem'
 
@@ -123,7 +123,7 @@ try
             }
 
             Context 'Application pool no value for managedRuntimeVersion' {
-                $result = Test-TargetResource -ApplyTo 'Machine' `
+                $result = Test-TargetResource -IsSingleInstance 'Yes' `
                             -IdentityType 'NetworkService'
 
                 It 'Should return True' {
@@ -155,7 +155,7 @@ try
             Mock Set-WebConfigurationProperty -MockWith { }
 
             Context 'Application pool defaults correct' {
-                Set-TargetResource -ApplyTo 'Machine' `
+                Set-TargetResource -IsSingleInstance 'Yes' `
                     -ManagedRuntimeVersion 'v4.0' `
                     -IdentityType 'NetworkService'
 
@@ -165,7 +165,7 @@ try
             }
 
             Context 'Application pool different managedRuntimeVersion' {
-                Set-TargetResource -ApplyTo 'Machine' `
+                Set-TargetResource -IsSingleInstance 'Yes' `
                     -ManagedRuntimeVersion 'v2.0' `
                     -IdentityType 'NetworkService'
 
@@ -176,7 +176,7 @@ try
             }
 
             Context 'Application pool different processModel/@identityType' {
-                Set-TargetResource -ApplyTo 'Machine' `
+                Set-TargetResource -IsSingleInstance 'Yes' `
                     -ManagedRuntimeVersion 'v4.0' `
                     -IdentityType 'LocalSystem'
 


### PR DESCRIPTION
This change brings the modules xWebAppPoolDefaults resource into
alignment with best practices for single instance resources.

When defining a resource that should only be allowed to be defined once
in any configuration, there are now best practices for how to implement
that restriction. There should be a single key property and its name
should be 'IsSingleInstance' with a value of 'Yes'. This change
implements that best practice.

Fixes #462

- [x] Added an entry to the change log under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/525)
<!-- Reviewable:end -->
