### PR TITLE
BREAKING CHANGE: xWebSiteDefaults: Align to best practices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,11 +52,13 @@
   - Moved MSFT_xWebVirtualDirectory localization strings to strings.psd1 ([issue #477](https://github.com/PowerShell/xWebAdministration/issues/477)).
 - Changes to xWebSiteDefaults
   - Move localization strings to strings.psd1 file ([issue #475](https://github.com/PowerShell/xWebAdministration/issues/475)).
+  - BREAKING CHANGE: Changed `ApplyTo` key parameter to `IsSingleInstance` to
+  bring the resource into compliance with published best practices. ([issue #457](https://github.com/PowerShell/xWebAdministration/issues/457))
 - Changes to xWebConfigProperty
   - Move localization strings to strings.psd1 file ([issue #473](https://github.com/PowerShell/xWebAdministration/issues/473)).
 - Changes to xWebConfigPropertyCollection
   - Move localization strings to strings.psd1 file ([issue #474](https://github.com/PowerShell/xWebAdministration/issues/474)).
-  
+
 ## 2.8.0.0
 
 - Fix multiple HTTPS bindings on one xWebsite receiving the first binding's certificate [#332](https://github.com/PowerShell/xWebAdministration/issues/332)

--- a/DSCResources/MSFT_xWebSiteDefaults/MSFT_xWebSiteDefaults.psm1
+++ b/DSCResources/MSFT_xWebSiteDefaults/MSFT_xWebSiteDefaults.psm1
@@ -19,9 +19,9 @@ function Get-TargetResource
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Machine')]
+        [ValidateSet('Yes')]
         [String]
-        $ApplyTo
+        $IsSingleInstance
     )
 
     Assert-Module
@@ -33,7 +33,7 @@ function Get-TargetResource
         TraceLogDirectory      = ( Get-Value 'siteDefaults/traceFailedRequestsLogging' 'directory')
         DefaultApplicationPool = (Get-Value 'applicationDefaults' 'applicationPool')
         AllowSubDirConfig      = (Get-Value 'virtualDirectoryDefaults' 'allowSubDirConfig')
-        ApplyTo                = 'Machine'
+        IsSingleInstance       = 'Yes'
         LogDirectory           = (Get-Value 'siteDefaults/logFile' 'directory')
     }
 
@@ -56,8 +56,8 @@ function Set-TargetResource
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Machine')]
-        [String] $ApplyTo,
+        [ValidateSet('Yes')]
+        [String] $IsSingleInstance,
 
         [Parameter()]
         [ValidateSet('W3C','IIS','NCSA','Custom')]
@@ -100,8 +100,8 @@ function Test-TargetResource
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Machine')]
-        [String] $ApplyTo,
+        [ValidateSet('Yes')]
+        [String] $IsSingleInstance,
 
         [Parameter()]
         [ValidateSet('W3C','IIS','NCSA','Custom')]

--- a/DSCResources/MSFT_xWebSiteDefaults/MSFT_xWebSiteDefaults.schema.mof
+++ b/DSCResources/MSFT_xWebSiteDefaults/MSFT_xWebSiteDefaults.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0"), FriendlyName("xWebSiteDefaults")] 
 class MSFT_xWebSiteDefaults : OMI_BaseResource
 {
-  [Key, Description("Dummy value because we need a key, always 'Machine'"), ValueMap{"Machine"}, Values{"Machine"}] string ApplyTo;
+  [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
   [write, Description("sites/siteDefaults/logFile/logFormat"), ValueMap{"W3C","IIS","NCSA","Custom"}, Values{"W3C","IIS","NCSA","Custom"}] string LogFormat;
   [write, Description("sites/siteDefaults/logFile/directory")] string LogDirectory;
   [write, Description("sites/siteDefaults/traceFailedRequestsLogging/directory")] string TraceLogDirectory;

--- a/Examples/Resources/xIisServerDefaults/Sample_xIisServerDefaults.ps1
+++ b/Examples/Resources/xIisServerDefaults/Sample_xIisServerDefaults.ps1
@@ -13,7 +13,7 @@ configuration Sample_xIISServerDefaults
     {
         xWebSiteDefaults SiteDefaults
         {
-            ApplyTo           = 'Machine'
+            IsSingleInstance  = 'Yes'
             LogFormat         = 'IIS'
             AllowSubDirConfig = 'true'
         }

--- a/Examples/Resources/xWebSiteDefaults/Sample_xWebSiteDefaults.ps1
+++ b/Examples/Resources/xWebSiteDefaults/Sample_xWebSiteDefaults.ps1
@@ -19,7 +19,7 @@ Configuration Sample_xWebSiteDefaults
     {
         xWebSiteDefaults SiteDefaults
         {
-            ApplyTo                = 'Machine'
+            IsSingleInstance       = 'Yes'
             LogFormat              = 'IIS'
             LogDirectory           = 'C:\inetpub\logs\LogFiles'
             TraceLogDirectory      = 'C:\inetpub\logs\FailedReqLogFiles'

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 
 ### xWebAppPoolDefaults
 
-* **ApplyTo**: Required Key value, always **Machine**
+* **IsSingleInstance**: Specifies the resource is a single instance, the value must be **Yes**
 * **ManagedRuntimeVersion**: CLR Version {v2.0|v4.0|} empty string for unmanaged.
 * **ApplicationPoolIdentity**: {ApplicationPoolIdentity | LocalService | LocalSystem | NetworkService}
 
@@ -928,7 +928,7 @@ configuration Sample_IISServerDefaults
     {
          xWebSiteDefaults SiteDefaults
          {
-            ApplyTo = 'Machine'
+            IsSingleInstance = 'Yes'
             LogFormat = 'IIS'
             LogTargetW3C = 'File,ETW'
             AllowSubDirConfig = 'true'

--- a/Tests/Integration/MSFT_xWebAppPoolDefaults.config.ps1
+++ b/Tests/Integration/MSFT_xWebAppPoolDefaults.config.ps1
@@ -43,7 +43,7 @@ configuration MSFT_xWebAppPoolDefaults_LogFormat
 
     xWebSiteDefaults LogFormat
     {
-        ApplyTo = 'Machine'
+        IsSingleInstance = 'Yes'
         LogFormat = $env:PesterLogFormat
     }
 }
@@ -54,7 +54,7 @@ configuration MSFT_xWebAppPoolDefaults_DefaultPool
 
     xWebSiteDefaults DefaultPool
     {
-        ApplyTo = 'Machine'
+        IsSingleInstance = 'Yes'
         DefaultApplicationPool = $env:PesterDefaultPool
     }
 }

--- a/Tests/Integration/MSFT_xWebsiteDefaults.config.ps1
+++ b/Tests/Integration/MSFT_xWebsiteDefaults.config.ps1
@@ -18,7 +18,7 @@ configuration MSFT_xWebsiteDefaults_Config
 
     xWebSiteDefaults virtualDirectoryDefaults
     {
-        ApplyTo = 'Machine'
+        IsSingleInstance = 'Yes'
         AllowSubDirConfig = "$env:PesterVirtualDirectoryDefaults"
     }
 }


### PR DESCRIPTION
This change brings the modules xWebSiteDefaults resource into
alignment with best practices for single instance resources.

When defining a resource that should only be allowed to be defined once
in any configuration, there are now best practices for how to implement
that restriction. There should be a single key property and its name
should be 'IsSingleInstance' with a value of 'Yes'. This change
implements that best practice.

Fixes #457

[x] Added an entry to the change log under the Unreleased section of the CHANGELOG.md.
Entry should say what was changed and how that affects users (if applicable), and
reference the issue being resolved (if applicable).
[x] Resource documentation added/updated in README.md.
[x] Resource parameter descriptions added/updated in README.md, schema.mof
and comment-based help.
[ ] Comment-based help added/updated.
[ ] Localization strings added/updated in all localization files as appropriate.
[x] Examples appropriately added/updated.
[ ] Unit tests added/updated. See DSC Resource Testing Guidelines.
[x] Integration tests added/updated (where possible). See DSC Resource Testing Guidelines.
[x] New/changed code adheres to DSC Resource Style Guidelines and Best Practices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwebadministration/527)
<!-- Reviewable:end -->
